### PR TITLE
Search Port Parameter

### DIFF
--- a/ardulink-core-serial-jssc/src/main/java/org/ardulink/core/serial/jssc/SerialLinkConfig.java
+++ b/ardulink-core-serial-jssc/src/main/java/org/ardulink/core/serial/jssc/SerialLinkConfig.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.Min;
 
 import org.ardulink.core.linkmanager.LinkConfig;
 import org.ardulink.core.linkmanager.LinkConfig.I18n;
+import org.ardulink.core.linkmanager.LinkConfig.Named;
 import org.ardulink.core.proto.api.Protocol;
 import org.ardulink.core.proto.api.Protocols;
 import org.ardulink.core.proto.impl.ArdulinkProtocol2;
@@ -63,6 +64,9 @@ public class SerialLinkConfig implements LinkConfig {
 	@Named("pingprobe")
 	private boolean pingprobe = true;
 
+	@Named("searchport")
+	private boolean searchport;
+	
 	public int getBaudrate() {
 		return baudrate;
 	}
@@ -133,4 +137,11 @@ public class SerialLinkConfig implements LinkConfig {
 		this.waitsecs = waitsecs;
 	}
 
+	public boolean isSearchport() {
+		return searchport;
+	}
+
+	public void setSearchport(boolean searchport) {
+		this.searchport = searchport;
+	}
 }

--- a/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/SerialLinkFactoryIntegrationTest.java
+++ b/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/SerialLinkFactoryIntegrationTest.java
@@ -21,11 +21,13 @@ import static java.lang.Boolean.TRUE;
 import static org.ardulink.util.Lists.newArrayList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -37,9 +39,12 @@ import org.ardulink.core.events.RplyListener;
 import org.ardulink.core.linkmanager.LinkManager;
 import org.ardulink.core.linkmanager.LinkManager.ConfigAttribute;
 import org.ardulink.core.linkmanager.LinkManager.Configurer;
+import org.ardulink.core.serial.jssc.SerialLinkConfig;
 import org.ardulink.util.URIs;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import jssc.SerialPortList;
 
@@ -53,8 +58,11 @@ import jssc.SerialPortList;
  */
 public class SerialLinkFactoryIntegrationTest {
 	
-	private Link link;
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
 
+	private Link link;
+	
 	@Test
 	public void canConfigureSerialConnectionViaURI() throws Exception {
 		String[] portNames = SerialPortList.getPortNames();
@@ -74,15 +82,17 @@ public class SerialLinkFactoryIntegrationTest {
 		Configurer configurer = connectionManager.getConfigurer(URIs.newURI("ardulink://serial-jssc"));
 
 		assertThat(newArrayList(configurer.getAttributes()),
-				is(newArrayList("port", "baudrate", "proto", "qos", "waitsecs", "pingprobe")));
+				is(newArrayList("port", "baudrate", "proto", "qos", "waitsecs", "pingprobe", "searchport")));
 
 		ConfigAttribute port = configurer.getAttribute("port");
 		ConfigAttribute proto = configurer.getAttribute("proto");
 		ConfigAttribute baudrate = configurer.getAttribute("baudrate");
+		ConfigAttribute searchport = configurer.getAttribute("searchport");
 
 		assertThat(port.hasChoiceValues(), is(TRUE));
 		assertThat(proto.hasChoiceValues(), is(TRUE));
 		assertThat(baudrate.hasChoiceValues(), is(FALSE));
+		assertThat(searchport.hasChoiceValues(), is(FALSE));
 
 		assertThat(port.getChoiceValues(), is(notNullValue()));
 
@@ -132,6 +142,38 @@ public class SerialLinkFactoryIntegrationTest {
 		
 		link.close();
 	}
+	
+	@Test
+	public void cantConnectWithoutPort() {
+		LinkManager connectionManager = LinkManager.getInstance();
+		Configurer configurer = connectionManager
+				.getConfigurer(URIs.newURI("ardulink://serial-jssc?baudrate=9600"));
+		
+		ConfigAttribute searchport = configurer.getAttribute("searchport");
+		assertEquals(searchport.getValue(), FALSE);
+
+		exception.expect(IllegalStateException.class);
+		
+		configurer.newLink();
+	}
+
+	@Test
+	public void canConnectWithoutPortButSearchEnabled() {
+		LinkManager connectionManager = LinkManager.getInstance();
+		Configurer configurer = connectionManager
+				.getConfigurer(URIs.newURI("ardulink://serial-jssc?searchport=true&baudrate=9600"));
+		
+		ConfigAttribute searchport = configurer.getAttribute("searchport");
+		assertEquals(searchport.getValue(), TRUE);
+		
+		// if there aren't devices connected an exception is thrown
+		ConfigAttribute port = configurer.getAttribute("port");
+		if(port.getChoiceValues().length == 0) {
+			exception.expectMessage("no port found");
+		}
+		assertNotNull(configurer.newLink());
+	}
+	
 	
 	public void sendCustom() throws IOException {
 		link.sendCustomMessage("getUniqueID", "XXX");

--- a/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/SerialLinkFactoryIntegrationTest.java
+++ b/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/SerialLinkFactoryIntegrationTest.java
@@ -161,7 +161,7 @@ public class SerialLinkFactoryIntegrationTest {
 	public void canConnectWithoutPortButSearchEnabled() {
 		LinkManager connectionManager = LinkManager.getInstance();
 		Configurer configurer = connectionManager
-				.getConfigurer(URIs.newURI("ardulink://serial-jssc?searchport=true&baudrate=9600"));
+				.getConfigurer(URIs.newURI("ardulink://serial-jssc?searchport=true&baudrate=9600&pingprobe=false"));
 		
 		ConfigAttribute searchport = configurer.getAttribute("searchport");
 		assertEquals(searchport.getValue(), TRUE);

--- a/ardulink-core-serial-rxtx/src/main/java/org/ardulink/core/serial/rxtx/SerialLinkConfig.java
+++ b/ardulink-core-serial-rxtx/src/main/java/org/ardulink/core/serial/rxtx/SerialLinkConfig.java
@@ -67,6 +67,9 @@ public class SerialLinkConfig implements LinkConfig {
 	@Named("pingprobe")
 	private boolean pingprobe = true;
 
+	@Named("searchport")
+	private boolean searchport;
+	
 	public int getBaudrate() {
 		return baudrate;
 	}
@@ -150,4 +153,11 @@ public class SerialLinkConfig implements LinkConfig {
 		this.waitsecs = waitsecs;
 	}
 
+	public boolean isSearchport() {
+		return searchport;
+	}
+
+	public void setSearchport(boolean searchport) {
+		this.searchport = searchport;
+	}
 }

--- a/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/connectionmanager/SerialLinkFactoryIntegrationTest.java
+++ b/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/connectionmanager/SerialLinkFactoryIntegrationTest.java
@@ -21,15 +21,20 @@ import static java.lang.Boolean.TRUE;
 import static org.ardulink.util.Lists.newArrayList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+
+import java.util.List;
 
 import org.ardulink.core.linkmanager.LinkManager;
 import org.ardulink.core.linkmanager.LinkManager.ConfigAttribute;
 import org.ardulink.core.linkmanager.LinkManager.Configurer;
+import org.ardulink.core.serial.rxtx.SerialLinkConfig;
 import org.ardulink.util.URIs;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -40,9 +45,12 @@ import org.junit.Test;
  *
  */
 // because JNI dependent
-@Ignore
+// @Ignore
 public class SerialLinkFactoryIntegrationTest {
 
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+	
 	@Test
 	public void canConfigureSerialConnectionViaURI() throws Exception {
 		LinkManager connectionManager = LinkManager.getInstance();
@@ -57,11 +65,13 @@ public class SerialLinkFactoryIntegrationTest {
 		Configurer configurer = connectionManager.getConfigurer(URIs.newURI("ardulink://serial"));
 
 		assertThat(newArrayList(configurer.getAttributes()),
-				is(newArrayList("port", "baudrate", "proto", "qos", "waitsecs", "pingprobe")));
+				is(newArrayList("port", "baudrate", "proto", "qos", "waitsecs", "pingprobe", "searchport")));
 
 		ConfigAttribute port = configurer.getAttribute("port");
 		ConfigAttribute proto = configurer.getAttribute("proto");
 		ConfigAttribute baudrate = configurer.getAttribute("baudrate");
+		ConfigAttribute searchport = configurer.getAttribute("searchport");
+		assertThat(searchport.hasChoiceValues(), is(FALSE));
 
 		assertThat(port.hasChoiceValues(), is(TRUE));
 		assertThat(proto.hasChoiceValues(), is(TRUE));
@@ -72,5 +82,36 @@ public class SerialLinkFactoryIntegrationTest {
 		port.setValue("anyString");
 		baudrate.setValue(115200);
 	}
+	
+	@Test
+	public void cantConnectWithoutPort() {
+		LinkManager connectionManager = LinkManager.getInstance();
+		Configurer configurer = connectionManager
+				.getConfigurer(URIs.newURI("ardulink://serial?baudrate=9600"));
+		
+		ConfigAttribute searchport = configurer.getAttribute("searchport");
+		assertEquals(searchport.getValue(), FALSE);
 
+		exception.expect(IllegalStateException.class);
+		
+		configurer.newLink();
+	}
+
+	@Test
+	public void canConnectWithoutPortButSearchEnabled() {
+		LinkManager connectionManager = LinkManager.getInstance();
+		Configurer configurer = connectionManager
+				.getConfigurer(URIs.newURI("ardulink://serial?searchport=true&baudrate=9600"));
+		
+		ConfigAttribute searchport = configurer.getAttribute("searchport");
+		assertEquals(searchport.getValue(), TRUE);
+		
+		// if there aren't devices connected an exception is thrown
+		ConfigAttribute port = configurer.getAttribute("port");
+		if(port.getChoiceValues().length == 0) {
+			exception.expectMessage("no port found");
+		}
+
+		assertNotNull(configurer.newLink());
+	}
 }

--- a/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/connectionmanager/SerialLinkFactoryIntegrationTest.java
+++ b/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/connectionmanager/SerialLinkFactoryIntegrationTest.java
@@ -25,13 +25,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import java.util.List;
-
 import org.ardulink.core.linkmanager.LinkManager;
 import org.ardulink.core.linkmanager.LinkManager.ConfigAttribute;
 import org.ardulink.core.linkmanager.LinkManager.Configurer;
-import org.ardulink.core.serial.rxtx.SerialLinkConfig;
 import org.ardulink.util.URIs;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -45,7 +43,7 @@ import org.junit.rules.ExpectedException;
  *
  */
 // because JNI dependent
-// @Ignore
+@Ignore
 public class SerialLinkFactoryIntegrationTest {
 
 	@Rule
@@ -101,7 +99,7 @@ public class SerialLinkFactoryIntegrationTest {
 	public void canConnectWithoutPortButSearchEnabled() {
 		LinkManager connectionManager = LinkManager.getInstance();
 		Configurer configurer = connectionManager
-				.getConfigurer(URIs.newURI("ardulink://serial?searchport=true&baudrate=9600"));
+				.getConfigurer(URIs.newURI("ardulink://serial?searchport=true&baudrate=9600&pingprobe=false"));
 		
 		ConfigAttribute searchport = configurer.getAttribute("searchport");
 		assertEquals(searchport.getValue(), TRUE);


### PR DESCRIPTION
Search Port Parameter added to serial Links (RXTX and JSSC). Now it is possible to specify searchport=true instead of port=something in connection URIs. Link factory will search for the first available port.