### PR TITLE
Support for docker

### DIFF
--- a/ardulink-core-base/src/main/java/org/ardulink/core/StreamReader.java
+++ b/ardulink-core-base/src/main/java/org/ardulink/core/StreamReader.java
@@ -45,7 +45,7 @@ public abstract class StreamReader implements Closeable {
 	}
 
 	public void runReaderThread(final byte[] delimiter) {
-		scanner = new StreamScanner(inputStream, delimiter);
+		this.scanner = new StreamScanner(this.inputStream, delimiter);
 		this.thread = new Thread() {
 
 			{
@@ -61,10 +61,8 @@ public abstract class StreamReader implements Closeable {
 		};
 	}
 
-	public void readUntilClosed(byte[] delimiter) {
-		
+	private void readUntilClosed(byte[] delimiter) {
 		try {
-						
 			while (scanner.hasNext() && !this.thread.isInterrupted()) {
 				try {
 					logger.debug("Waiting for data");

--- a/ardulink-networkproxyserver/pom.xml
+++ b/ardulink-networkproxyserver/pom.xml
@@ -24,7 +24,26 @@
 					</archive>
 				</configuration>
 			</plugin>
-		</plugins>
+                        <plugin>
+                                <groupId>com.google.cloud.tools</groupId>
+                                <artifactId>jib-maven-plugin</artifactId>
+                                <configuration>
+					<container>
+						<useCurrentTimestamp>true</useCurrentTimestamp>
+						<!-- bug in JIB? classes of dependent projects resides in /app/libs/classes but this is missing in cp -->
+						<entrypoint>
+							<arg>java</arg>
+							<arg>-cp</arg>
+							<arg>/app/resources:/app/classes:/app/libs/classes:/app/libs/*</arg>
+							<arg>org.ardulink.connection.proxy.NetworkProxyServer</arg>
+						</entrypoint>
+					</container>
+                                        <skip>false</skip>
+					<args>start</args>
+					<ports>4478</ports>
+                                </configuration>
+                        </plugin>
+                </plugins>
 	</build>
 
 	<dependencies>

--- a/ardulink-networkproxyserver/src/main/java/org/ardulink/connection/proxy/NetworkProxyServerConnection.java
+++ b/ardulink-networkproxyserver/src/main/java/org/ardulink/connection/proxy/NetworkProxyServerConnection.java
@@ -93,7 +93,7 @@ public class NetworkProxyServerConnection implements Runnable {
 				}
 			};
 			try {
-				streamReader.readUntilClosed(proto.getSeparator());
+				streamReader.runReaderThread(proto.getSeparator());
 			} finally {
 				streamReader.close();
 			}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,8 @@
 		<args4j.version>2.32</args4j.version>
 		<slf4j.version>1.7.12</slf4j.version>
 		<junit.version>4.12</junit.version>
+		<!-- default image name for JIB -->
+		<image>docker.io/ardulink/${project.artifactId}:${project.version}</image>
 	</properties>
 
 	<modules>
@@ -140,6 +142,14 @@
 						</configuration>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.google.cloud.tools</groupId>
+				<artifactId>jib-maven-plugin</artifactId>
+				<version>0.9.13</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
This is a work in progress but PR can be merged. Docker images now can be build by calling `mvn compile jib:dockerBuild`

The docker container can then be started by calling `docker run --rm --privileged -p4478:4478 ardulink/ardulink-networkproxyserver:2.1.1-SNAPSHOT`. When networkproxyserver tries to initialize RXTX (when it is connected itself) it will fail because RXTX lib is missing inside the docker image. 

We have to be decide if we switch to JSSC here or add lib-RXTX to the container. @LucianoZu The reason for the PR instead of pushing this change to master directly is that I'd like that you can join this decision, so please accept and comment, I will then do the missing part. 

