### PR TITLE
migration from JUnit4->JUnit5

### DIFF
--- a/ardulink-camel/pom.xml
+++ b/ardulink-camel/pom.xml
@@ -10,13 +10,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<!-- camel3 depends on Java8 -->
-	<properties>
-		<compilerVersion>1.8</compilerVersion>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -33,9 +26,14 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/ardulink-camel/src/test/java/org/ardulink/camel/test/ArdulinkComponentListenerTest.java
+++ b/ardulink-camel/src/test/java/org/ardulink/camel/test/ArdulinkComponentListenerTest.java
@@ -1,6 +1,5 @@
 package org.ardulink.camel.test;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.ardulink.core.Pin.analogPin;
 import static org.ardulink.core.Pin.digitalPin;
 import static org.ardulink.testsupport.mock.TestSupport.getMock;
@@ -14,33 +13,30 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.ardulink.core.Link;
 import org.ardulink.core.convenience.Links;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-public class ArdulinkComponentListenerTest {
-
-	@Rule
-	public Timeout timeout = new Timeout(5, SECONDS);
+@Timeout(5)
+class ArdulinkComponentListenerTest {
 
 	private static final String MOCK_URI = "ardulink://mock";
 
 	private Link link;
 
-	@Before
-	public void setup() throws Exception {
+	@BeforeEach
+	void setup() throws Exception {
 		link = Links.getLink(MOCK_URI);
 	}
 
-	@After
-	public void tearDown() throws IOException {
+	@AfterEach
+	void tearDown() throws IOException {
 		link.close();
 	}
 
 	@Test
-	public void startListeningOnPassedPins() throws Exception {
+	void startListeningOnPassedPins() throws Exception {
 		haltCamel(startCamel("listenTo=d1,d2,a1"));
 		Link mock = getMock(link);
 		verify(mock).startListening(digitalPin(1));
@@ -51,7 +47,7 @@ public class ArdulinkComponentListenerTest {
 	}
 
 	@Test
-	public void listeningIsCaseInsensitive() throws Exception {
+	void listeningIsCaseInsensitive() throws Exception {
 		haltCamel(startCamel("listenTo=d1,D2,a3,A4"));
 		Link mock = getMock(link);
 		verify(mock).startListening(digitalPin(1));
@@ -63,7 +59,7 @@ public class ArdulinkComponentListenerTest {
 	}
 
 	@Test
-	public void ignoresMultipleOccurencesOfSamePin() throws Exception {
+	void ignoresMultipleOccurencesOfSamePin() throws Exception {
 		haltCamel(startCamel("listenTo=d1,D1,a2,A2"));
 		Link mock = getMock(link);
 		verify(mock).startListening(digitalPin(1));

--- a/ardulink-camel/src/test/java/org/ardulink/camel/test/ArdulinkComponentTest.java
+++ b/ardulink-camel/src/test/java/org/ardulink/camel/test/ArdulinkComponentTest.java
@@ -32,13 +32,13 @@ import org.ardulink.core.Pin.DigitalPin;
 import org.ardulink.core.convenience.Links;
 import org.ardulink.core.linkmanager.LinkConfig;
 import org.ardulink.core.linkmanager.LinkFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-public class ArdulinkComponentTest {
+class ArdulinkComponentTest {
 
 	private static final String IN = "direct:in";
 
@@ -48,48 +48,48 @@ public class ArdulinkComponentTest {
 
 	private CamelContext context;
 
-	@Before
-	public void setup() throws Exception {
+	@BeforeEach
+	void setup() throws Exception {
 		context = camelContext(IN, MOCK_URI);
 		link = Links.getLink(MOCK_URI);
 	}
 
-	@After
-	public void tearDown() throws Exception {
+	@AfterEach
+	void tearDown() throws Exception {
 		link.close();
 		context.stop();
 	}
 
 	@Test
-	public void canSwitchDigitalPin2On() throws Exception {
+	void canSwitchDigitalPin2On() throws Exception {
 		testDigital(digitalPin(2), true);
 	}
 
 	@Test
-	public void canSwitchDigitalPin2Off() throws Exception {
+	void canSwitchDigitalPin2Off() throws Exception {
 		testDigital(digitalPin(2), false);
 	}
 
 	@Test
-	public void canSwitchDigitalPin3() throws Exception {
+	void canSwitchDigitalPin3() throws Exception {
 		testDigital(digitalPin(3), true);
 	}
 
 	@Test
-	public void canSwitchAnalogPin3() throws Exception {
+	void canSwitchAnalogPin3() throws Exception {
 		testAnalog(analogPin(5), 123);
 	}
 
 	@Test
-	@Ignore
-	public void ignoresNegativeValues() {
+	@Disabled
+	void ignoresNegativeValues() {
 		send(alpProtocolMessage(ANALOG_PIN_READ).forPin(analogPin(6).pinNum()).withValue(-1));
 		Link mock = getMock(link);
 		verifyNoMoreInteractions(mock);
 	}
 
 	@Test
-	public void canEnableAnalogListening() throws Exception {
+	void canEnableAnalogListening() throws Exception {
 		send(alpProtocolMessage(START_LISTENING_ANALOG).forPin(analogPin(6).pinNum()).withoutValue());
 		Link mock = getMock(link);
 		verify(mock).startListening(analogPin(6));
@@ -97,7 +97,7 @@ public class ArdulinkComponentTest {
 	}
 
 	@Test
-	public void canEnableDigitalListening() throws Exception {
+	void canEnableDigitalListening() throws Exception {
 		send(alpProtocolMessage(START_LISTENING_DIGITAL).forPin(digitalPin(7).pinNum()).withoutValue());
 		Link mock = getMock(link);
 		verify(mock).startListening(digitalPin(7));
@@ -105,7 +105,7 @@ public class ArdulinkComponentTest {
 	}
 
 	@Test
-	public void canDisableAnalogListening() throws Exception {
+	void canDisableAnalogListening() throws Exception {
 		send(alpProtocolMessage(START_LISTENING_ANALOG).forPin(6).withoutValue());
 		send(alpProtocolMessage(STOP_LISTENING_ANALOG).forPin(6).withoutValue());
 		Link mock = getMock(link);
@@ -115,7 +115,7 @@ public class ArdulinkComponentTest {
 	}
 
 	@Test
-	public void canDisableDigitalListening() throws Exception {
+	void canDisableDigitalListening() throws Exception {
 		send(alpProtocolMessage(START_LISTENING_DIGITAL).forPin(7).withoutValue());
 		send(alpProtocolMessage(STOP_LISTENING_DIGITAL).forPin(7).withoutValue());
 		Link mock = getMock(link);
@@ -188,7 +188,7 @@ public class ArdulinkComponentTest {
 	}
 
 	@Test
-	public void canSetLinkParameters() throws Exception {
+	void canSetLinkParameters() throws Exception {
 		String a = "foo";
 		String b = "HOURS";
 		String name = "factoryName-" + randomUUID();

--- a/ardulink-camel/src/test/java/org/ardulink/camel/test/ArdulinkConsumerIntegrationTest.java
+++ b/ardulink-camel/src/test/java/org/ardulink/camel/test/ArdulinkConsumerIntegrationTest.java
@@ -16,14 +16,14 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.ardulink.core.Link;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ArdulinkConsumerIntegrationTest {
+class ArdulinkConsumerIntegrationTest {
 
 	private static final String OUT = "mock:result";
 
 	@Test
-	public void messageIsSentOnAnalogPinChange() throws Exception {
+	void messageIsSentOnAnalogPinChange() throws Exception {
 		int pin = 2;
 		int value = 42;
 		try (Link link = createAbstractListenerLink(analogPinValueChanged(analogPin(pin), value));
@@ -35,7 +35,7 @@ public class ArdulinkConsumerIntegrationTest {
 	}
 
 	@Test
-	public void messageIsSentOnDigitalPinChange() throws Exception {
+	void messageIsSentOnDigitalPinChange() throws Exception {
 		int pin = 3;
 		boolean state = true;
 		try (Link link = createAbstractListenerLink(digitalPinValueChanged(digitalPin(pin), state));

--- a/ardulink-console/pom.xml
+++ b/ardulink-console/pom.xml
@@ -92,9 +92,14 @@
 			<artifactId>args4j</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/ardulink-console/src/test/java/org/ardulink/gui/ConsoleTest.java
+++ b/ardulink-console/src/test/java/org/ardulink/gui/ConsoleTest.java
@@ -6,19 +6,19 @@ import static java.lang.Boolean.TRUE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assumptions.*;
 import static org.mockito.Mockito.mock;
 
 import org.ardulink.legacy.Link;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ConsoleTest {
+class ConsoleTest {
 
 	private final Link connectLink = mock(Link.class);
 
 	@Test
-	public void whenStartedConnectIsEnabledAndDisconnnectIsDisabled() {
-		assumeThat(isHeadless(), is(FALSE));
+	void whenStartedConnectIsEnabledAndDisconnnectIsDisabled() {
+		assumeFalse(isHeadless());
 		Console console = newConsole();
 		assertThat(console.getLink(), is(nullValue()));
 		assertThat(console.btnConnect.isEnabled(), is(TRUE));
@@ -26,8 +26,8 @@ public class ConsoleTest {
 	}
 
 	@Test
-	public void whenConnectButtonIsClickedLinkIsExchangedAndPopertyChangeEventsIsFired() {
-		assumeThat(isHeadless(), is(FALSE));
+	void whenConnectButtonIsClickedLinkIsExchangedAndPopertyChangeEventsIsFired() {
+		assumeFalse(isHeadless());
 		Console console = newConsole();
 		console.btnConnect.doClick();
 
@@ -37,8 +37,8 @@ public class ConsoleTest {
 	}
 
 	@Test
-	public void whenDisconnectButtonIsClickedLinkIsExchangedAndPopertyChangeEventsIsFired() {
-		assumeThat(isHeadless(), is(FALSE));
+	void whenDisconnectButtonIsClickedLinkIsExchangedAndPopertyChangeEventsIsFired() {
+		assumeFalse(isHeadless());
 		Console console = newConsole();
 		console.btnConnect.doClick();
 		console.btnDisconnect.doClick();

--- a/ardulink-core-base/pom.xml
+++ b/ardulink-core-base/pom.xml
@@ -31,9 +31,14 @@
 			<version>2.0.1.Final</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/ardulink-core-base/src/test/java/org/ardulink/core/ConnectionBasedLinkTest.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/ConnectionBasedLinkTest.java
@@ -56,11 +56,10 @@ import org.ardulink.core.proto.impl.ArdulinkProtocol2;
 import org.ardulink.util.Joiner;
 import org.ardulink.util.Lists;
 import org.ardulink.util.anno.LapsedWith;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -70,10 +69,8 @@ import org.junit.rules.Timeout;
  * [adsense]
  *
  */
-public class ConnectionBasedLinkTest {
-
-	@Rule
-	public Timeout timeout = new Timeout(5, SECONDS);
+@Timeout(5)
+class ConnectionBasedLinkTest {
 
 	// TODO PF Migrate to @Rule Arduino
 	private PipedOutputStream arduinosOutputStream;
@@ -82,8 +79,8 @@ public class ConnectionBasedLinkTest {
 	private ConnectionBasedLink link;
 	private final AtomicInteger bytesNotYetRead = new AtomicInteger();
 
-	@Before
-	public void setup() throws IOException {
+	@BeforeEach
+	void setup() throws IOException {
 		PipedInputStream pis = new PipedInputStream();
 		this.arduinosOutputStream = new PipedOutputStream(pis);
 		ByteStreamProcessor byteStreamProcessor = new ArdulinkProtocol2().newByteStreamProcessor();
@@ -97,15 +94,15 @@ public class ConnectionBasedLinkTest {
 		this.link = new ConnectionBasedLink(connection, byteStreamProcessor);
 	}
 
-	@After
-	public void tearDown() throws IOException {
+	@AfterEach
+	void tearDown() throws IOException {
 		if (this.link != null) {
 			this.link.close();
 		}
 	}
 
 	@Test
-	public void canSendAnalogValue() throws IOException {
+	void canSendAnalogValue() throws IOException {
 		int pin = anyPositive(int.class);
 		int value = anyPositive(int.class);
 		this.link.switchAnalogPin(analogPin(pin), value);
@@ -113,21 +110,21 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void canSendDigitalValue() throws IOException {
+	void canSendDigitalValue() throws IOException {
 		int pin = anyPositive(int.class);
 		this.link.switchDigitalPin(digitalPin(pin), true);
 		assertToArduinoWasSent(alpProtocolMessage(POWER_PIN_SWITCH).forPin(pin).withState(true));
 	}
 
 	@Test
-	public void doesSendStartListeningAnalogCommangToArduino() throws IOException {
+	void doesSendStartListeningAnalogCommangToArduino() throws IOException {
 		int pin = anyPositive(int.class);
 		this.link.addListener(new FilteredEventListenerAdapter(analogPin(pin), null));
 		assertToArduinoWasSent(alpProtocolMessage(START_LISTENING_ANALOG).forPin(pin).withoutValue());
 	}
 
 	@Test
-	public void doesSendStopListeningAnalogCommangToArduino() throws IOException {
+	void doesSendStopListeningAnalogCommangToArduino() throws IOException {
 		int pin = anyPositive(int.class);
 		FilteredEventListenerAdapter l1 = new FilteredEventListenerAdapter(analogPin(pin), null);
 		FilteredEventListenerAdapter l2 = new FilteredEventListenerAdapter(analogPin(pin), null);
@@ -143,7 +140,7 @@ public class ConnectionBasedLinkTest {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void canReceiveAnalogPinChange() throws IOException {
+	void canReceiveAnalogPinChange() throws IOException {
 		final List<PinValueChangedEvent> analogEvents = new ArrayList<PinValueChangedEvent>();
 		EventListenerAdapter listener = new EventListenerAdapter() {
 			@Override
@@ -161,7 +158,7 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void doesSendStartListeningDigitalCommangToArduino() throws IOException {
+	void doesSendStartListeningDigitalCommangToArduino() throws IOException {
 		int pin = anyPositive(int.class);
 		this.link.addListener(new FilteredEventListenerAdapter(digitalPin(pin), null));
 		assertToArduinoWasSent(alpProtocolMessage(START_LISTENING_DIGITAL).forPin(pin).withoutValue());
@@ -169,7 +166,7 @@ public class ConnectionBasedLinkTest {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void canReceiveDigitalPinChange() throws IOException {
+	void canReceiveDigitalPinChange() throws IOException {
 		final List<PinValueChangedEvent> digitalEvents = new ArrayList<PinValueChangedEvent>();
 		EventListenerAdapter listener = new EventListenerAdapter() {
 			@Override
@@ -186,7 +183,7 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void canFilterPins() throws IOException {
+	void canFilterPins() throws IOException {
 		int pin = anyPositive(int.class);
 		final List<DigitalPinValueChangedEvent> digitalEvents = new ArrayList<DigitalPinValueChangedEvent>();
 		EventListenerAdapter listener = new EventListenerAdapter() {
@@ -204,44 +201,44 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void canSendKbdEvents() throws IOException {
+	void canSendKbdEvents() throws IOException {
 		this.link.sendKeyPressEvent('#', 1, 2, 3, 4);
 		assertToArduinoWasSent("alp://kprs/chr#cod1loc2mod3mex4");
 	}
 
 	@Test
-	public void canSendToneWithDuration() throws IOException {
+	void canSendToneWithDuration() throws IOException {
 		this.link.sendTone(Tone.forPin(analogPin(2)).withHertz(3000).withDuration(5, SECONDS));
 		assertToArduinoWasSent("alp://tone/2/3000/5000");
 	}
 
 	@Test
-	public void canSendEndlessTone() throws IOException {
+	void canSendEndlessTone() throws IOException {
 		this.link.sendTone(Tone.forPin(analogPin(2)).withHertz(3000).endless());
 		assertToArduinoWasSent("alp://tone/2/3000/-1");
 	}
 
 	@Test
-	public void canSendNoTone() throws IOException {
+	void canSendNoTone() throws IOException {
 		this.link.sendNoTone(analogPin(5));
 		assertToArduinoWasSent("alp://notn/5");
 	}
 
 	@Test
-	public void canSendCustomMessageSingleValue() throws IOException {
+	void canSendCustomMessageSingleValue() throws IOException {
 		String message = "myMessage";
 		this.link.sendCustomMessage(message);
 		assertToArduinoWasSent("alp://cust/" + message);
 	}
 
 	@Test
-	public void canSendCustomMessageMultiValue() throws IOException {
+	void canSendCustomMessageMultiValue() throws IOException {
 		this.link.sendCustomMessage("1", "2", "3");
 		assertToArduinoWasSent("alp://cust/1/2/3");
 	}
 
 	@Test
-	public void canReadRawMessagesRead() throws IOException {
+	void canReadRawMessagesRead() throws IOException {
 		String message = alpProtocolMessage(DIGITAL_PIN_READ).forPin(anyPositive(int.class)).withState(true);
 		final StringBuilder sb = new StringBuilder();
 		this.connection.addListener(new ListenerAdapter() {
@@ -256,7 +253,7 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void canReadRawMessagesSent() throws IOException {
+	void canReadRawMessagesSent() throws IOException {
 		final StringBuilder sb = new StringBuilder();
 		this.connection.addListener(new ListenerAdapter() {
 			@Override
@@ -271,7 +268,7 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void twoListenersMustNotInference() throws IOException {
+	void twoListenersMustNotInference() throws IOException {
 		this.link.addListener(new EventListener() {
 			@Override
 			public void stateChanged(AnalogPinValueChangedEvent event) {
@@ -305,7 +302,7 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void unparseableInput() throws IOException {
+	void unparseableInput() throws IOException {
 		String m1 = "eXTRaoRdINARy dATa";
 		simulateArduinoSend(m1);
 		String m2 = alpProtocolMessage(DIGITAL_PIN_READ).forPin(anyPositive(int.class)).withState(true);
@@ -315,7 +312,7 @@ public class ConnectionBasedLinkTest {
 	}
 
 	@Test
-	public void doesDeregisterAllListenersBeforeClosing() throws IOException {
+	void doesDeregisterAllListenersBeforeClosing() throws IOException {
 		final StringBuilder sb = new StringBuilder();
 		this.link.addListener(new EventListener() {
 			@Override

--- a/ardulink-core-base/src/test/java/org/ardulink/core/convenience/LinksTest.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/convenience/LinksTest.java
@@ -44,7 +44,7 @@ import org.ardulink.core.linkmanager.LinkConfig;
 import org.ardulink.core.linkmanager.LinkFactory;
 import org.ardulink.core.linkmanager.LinkManagerTest.AliasUsingLinkFactory;
 import org.ardulink.core.linkmanager.providers.LinkFactoriesProvider4Test.Statement;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -54,17 +54,17 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class LinksTest {
+class LinksTest {
 
 	@Test
-	public void whenRequestingDefaultLinkReturnsFirstAvailableConnectionIfSerialNotAvailable() throws IOException {
+	void whenRequestingDefaultLinkReturnsFirstAvailableConnectionIfSerialNotAvailable() throws IOException {
 		Link link = Links.getDefault();
 		assertThat(getConnection(link), instanceOf(DummyConnection.class));
 		close(link);
 	}
 
 	@Test
-	public void whenRequestingDefaultLinkSerialHasPriorityOverAllOthers() throws Exception {
+	void whenRequestingDefaultLinkSerialHasPriorityOverAllOthers() throws Exception {
 		final LinkFactory<LinkConfig> serial = spy(factoryNamed(serial()));
 		withRegistered(factoryNamed(serialDash("a")), factoryNamed("a"), serial, factoryNamed("z"),
 				factoryNamed(serialDash("z"))).execute(new Statement() {
@@ -76,7 +76,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void whenRequestingDefaultLinkStartingWithSerialDashHasPriorityOverAllOthers() throws Exception {
+	void whenRequestingDefaultLinkStartingWithSerialDashHasPriorityOverAllOthers() throws Exception {
 		final LinkFactory<LinkConfig> serialDashAnything = spy(factoryNamed(serialDash("appendix-does-not-matter")));
 		withRegistered(factoryNamed("a"), serialDashAnything, factoryNamed("z")).execute(new Statement() {
 			@Override
@@ -87,7 +87,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void serialDashDoesHandleSerial() throws Exception {
+	void serialDashDoesHandleSerial() throws Exception {
 		final LinkFactory<LinkConfig> serialDashAnything = spy(factoryNamed(serialDash("appendix-does-not-matter")));
 		withRegistered(serialDashAnything).execute(new Statement() {
 			@Override
@@ -106,7 +106,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void isConfiguredForAllChoiceValues() throws IOException {
+	void isConfiguredForAllChoiceValues() throws IOException {
 		Link link = Links.getDefault();
 		DummyLinkConfig config = getConnection(link).getConfig();
 		assertThat(config.getA(), is("aVal1"));
@@ -114,10 +114,10 @@ public class LinksTest {
 	}
 
 	@Test
-	public void registeredSpecialNameDefault() throws Exception {
+	void registeredSpecialNameDefault() throws Exception {
 		final LinkFactory<LinkConfig> serial = spy(factoryNamed(serial()));
-		assert serial.newLinkConfig()
-				.equals(NO_ATTRIBUTES) : "ardulink://default would differ if the config has attributes";
+		assert serial.newLinkConfig().equals(NO_ATTRIBUTES)
+				: "ardulink://default would differ if the config has attributes";
 		withRegistered(serial).execute(new Statement() {
 			@Override
 			public void execute() throws Exception {
@@ -130,7 +130,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void doesCacheLinks() throws IOException {
+	void doesCacheLinks() throws IOException {
 		String uri = "ardulink://dummyLink";
 		Link link1 = Links.getLink(uri);
 		Link link2 = Links.getLink(uri);
@@ -141,7 +141,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void doesCacheLinksWhenUsingDefaultValues() throws IOException {
+	void doesCacheLinksWhenUsingDefaultValues() throws IOException {
 		Link link1 = Links.getLink("ardulink://dummyLink");
 		Link link2 = Links.getLink("ardulink://dummyLink?a=&b=42&c=");
 		assertThat(link1, notNullValue());
@@ -151,7 +151,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void canCloseConnection() throws IOException {
+	void canCloseConnection() throws IOException {
 		Link link = getRandomLink();
 		DummyConnection connection = getConnection(link);
 		verify(connection, times(0)).close();
@@ -160,7 +160,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void doesNotCloseConnectionIfStillInUse() throws IOException {
+	void doesNotCloseConnectionIfStillInUse() throws IOException {
 		String randomURI = getRandomURI();
 		Link[] links = { createConnectionBasedLink(randomURI), createConnectionBasedLink(randomURI),
 				createConnectionBasedLink(randomURI) };
@@ -174,7 +174,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void afterClosingWeGetAfreshLink() throws IOException {
+	void afterClosingWeGetAfreshLink() throws IOException {
 		String randomURI = getRandomURI();
 		Link link1 = createConnectionBasedLink(randomURI);
 		Link link2 = createConnectionBasedLink(randomURI);
@@ -187,7 +187,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void stopsListenigAfterAllCallersLikeToStopListening() throws IOException {
+	void stopsListenigAfterAllCallersLikeToStopListening() throws IOException {
 		String randomURI = getRandomURI();
 		Link link0 = createConnectionBasedLink(randomURI);
 		Link link1 = createConnectionBasedLink(randomURI);
@@ -209,7 +209,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void twoDifferentURIsWithSameParamsMustNotBeenMixed() throws Exception {
+	void twoDifferentURIsWithSameParamsMustNotBeenMixed() throws Exception {
 		final String name1 = new DummyLinkFactory().getName();
 		final String name2 = "DummyLINK";
 		assert name1.equalsIgnoreCase(name2) && !name1.equals(name2);
@@ -236,7 +236,7 @@ public class LinksTest {
 	}
 
 	@Test
-	public void aliasLinksAreSharedToo() throws Exception {
+	void aliasLinksAreSharedToo() throws Exception {
 		withRegistered(new AliasUsingLinkFactory()).execute(new Statement() {
 			@Override
 			public void execute() throws IOException {

--- a/ardulink-core-base/src/test/java/org/ardulink/core/linkmanager/DummyLinkFactoryTest.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/linkmanager/DummyLinkFactoryTest.java
@@ -23,17 +23,16 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Locale.GERMAN;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.ardulink.util.anno.LapsedWith.JDK8;
+import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -46,10 +45,9 @@ import org.ardulink.core.linkmanager.LinkManager.Configurer;
 import org.ardulink.core.linkmanager.LinkManager.NumberValidationInfo;
 import org.ardulink.core.proto.impl.DummyProtocol;
 import org.ardulink.util.URIs;
-import org.ardulink.util.anno.LapsedWith;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -59,107 +57,87 @@ import org.junit.function.ThrowingRunnable;
  * [adsense]
  *
  */
-public class DummyLinkFactoryTest {
+class DummyLinkFactoryTest {
+
+	private final class ExecutableImplementation implements Executable {
+		@Override
+		public void execute() throws Throwable {
+			sut.getConfigurer(URIs.newURI("wrongSchema://dummy"));
+		}
+	}
 
 	private final LinkManager sut = LinkManager.getInstance();
 
 	@Test
-	public void throwsExceptionOnInvalidNames() {
-		final String name = "non.existing.name";
-		
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				sut.getConfigurer(URIs.newURI("ardulink://" + name + ""));
-			}
-		});
+	void throwsExceptionOnInvalidNames() {
+		String name = "non.existing.name";
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> sut.getConfigurer(URIs.newURI("ardulink://" + name + "")));
 		assertThat(exception.getMessage(), containsString("No factory registered for \"" + name + "\""));
 	}
 
 	@Test
-	public void schemaHasToBeArdulink() {
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				sut.getConfigurer(URIs.newURI("wrongSchema://dummy"));
-			}
-		});
+	void schemaHasToBeArdulink() {
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				new ExecutableImplementation());
 		assertThat(exception.getMessage(), containsString("schema not ardulink"));
 	}
 
 	@Test
-	public void canCreateDummyConnection() {
-		Link link = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"))
-				.newLink();
+	void canCreateDummyConnection() {
+		Link link = sut.getConfigurer(URIs.newURI("ardulink://dummyLink")).newLink();
 		assertThat(link, is(notNullValue()));
 	}
 
 	@Test
-	public void canConfigureDummyConnection() {
+	void canConfigureDummyConnection() {
 		String aValue = "aVal1";
 		int bValue = 1;
 		String cValue = "cValue";
 		TimeUnit eValue = TimeUnit.DAYS;
-		Link link = (Link) sut.getConfigurer(
-				URIs.newURI("ardulink://dummyLink?a=" + aValue + "&b=" + bValue
-						+ "&c=" + cValue + "&proto=dummyProto&e="
-						+ eValue.name())).newLink();
+		Link link = (Link) sut.getConfigurer(URIs.newURI("ardulink://dummyLink?a=" + aValue + "&b=" + bValue + "&c="
+				+ cValue + "&proto=dummyProto&e=" + eValue.name())).newLink();
 
 		assertThat(link, instanceOf(ConnectionBasedLink.class));
-		DummyConnection connection = (DummyConnection) ((ConnectionBasedLink) link)
-				.getConnection();
+		DummyConnection connection = (DummyConnection) ((ConnectionBasedLink) link).getConnection();
 		DummyLinkConfig config = connection.getConfig();
 		assertThat(config.a, is(aValue));
 		assertThat(config.b, is(bValue));
 		assertThat(config.c, is(cValue));
-		assertThat(config.protocol.getClass().getName(), is(DummyProtocol
-				.getInstance().getClass().getName()));
+		assertThat(config.protocol.getClass().getName(), is(DummyProtocol.getInstance().getClass().getName()));
 		assertThat(config.e, is(eValue));
 
 	}
 
 	@Test
-	public void enumsHaveDefaultChoiceValues() {
+	void enumsHaveDefaultChoiceValues() {
 		// if type is an enum and there is no @ChoiceFor defined the enum's
 		// constants should be returned
-		Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
 		ConfigAttribute e = configurer.getAttribute("e");
 		assertThat(e.hasChoiceValues(), is(TRUE));
-		assertThat(e.getChoiceValues(),
-				CoreMatchers.is((Object[]) TimeUnit.values()));
+		assertThat(e.getChoiceValues(), CoreMatchers.is((Object[]) TimeUnit.values()));
 	}
 
 	@Test
-	public void enumsWithChoiceValuesDoNotUseDefaultValues() {
-		Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
+	void enumsWithChoiceValuesDoNotUseDefaultValues() {
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
 		ConfigAttribute f = configurer.getAttribute("f");
 		assertThat(f.hasChoiceValues(), is(TRUE));
-		assertThat(Arrays.asList(f.getChoiceValues()),
-				is(Arrays.<Object> asList(NANOSECONDS, DAYS)));
+		assertThat(Arrays.asList(f.getChoiceValues()), is(Arrays.<Object>asList(NANOSECONDS, DAYS)));
 	}
 
 	@Test
-	public void throwsExceptionOnInvalidKey() {
-		final String nonExistingKey = "nonExistingKey";
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				sut.getConfigurer(URIs.newURI("ardulink://dummyLink?" + nonExistingKey
-						+ "=someValue"));
-			}
-		});
+	void throwsExceptionOnInvalidKey() {
+		String nonExistingKey = "nonExistingKey";
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> sut.getConfigurer(URIs.newURI("ardulink://dummyLink?" + nonExistingKey + "=someValue")));
 		assertThat(exception.getMessage(), containsString("Could not determine attribute " + nonExistingKey));
 	}
 
 	@Test
-	public void canDefineChoiceValues() throws Exception {
-		Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
+	void canDefineChoiceValues() throws Exception {
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
 		ConfigAttribute a = configurer.getAttribute("a");
 		assertThat(a.hasChoiceValues(), is(TRUE));
 		assertThat(a.getChoiceValues(), is(new Object[] { "aVal1", "aVal2" }));
@@ -169,122 +147,89 @@ public class DummyLinkFactoryTest {
 
 		ConfigAttribute proto = configurer.getAttribute("proto");
 		assertThat(proto.hasChoiceValues(), is(TRUE));
-		assertThat(Arrays.asList(proto.getChoiceValues()),
-				hasItems((Object) "dummyProto", "ardulink2"));
+		assertThat(Arrays.asList(proto.getChoiceValues()), hasItems((Object) "dummyProto", "ardulink2"));
 	}
 
 	@Test
-	public void cannotSetChoiceValuesThatDoNotExist_WithPreviousQuery() {
+	void cannotSetChoiceValuesThatDoNotExist_WithPreviousQuery() {
 		Locale.setDefault(ENGLISH);
-		final Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
 		ConfigAttribute a = configurer.getAttribute("a");
 		assertThat(a.getChoiceValues(), is(new Object[] { "aVal1", "aVal2" }));
 		String invalidValue = "aVal3IsNotAvalidValue";
 		a.setValue(invalidValue);
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				configurer.newLink();
-			}
-		});
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> configurer.newLink());
 		assertThat(exception.getMessage(), is(invalidValue + " is not a valid value for "
-				+ "A is meant just to be an example attribute"
-				+ ", valid values are [aVal1, aVal2]"));
+				+ "A is meant just to be an example attribute" + ", valid values are [aVal1, aVal2]"));
 	}
 
 	@Test
-	public void cannotSetChoiceValuesThatDoNotExist_WithoutPreviousQuery() {
+	void cannotSetChoiceValuesThatDoNotExist_WithoutPreviousQuery() {
 		Locale.setDefault(ENGLISH);
-		final Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
 		ConfigAttribute a = configurer.getAttribute("a");
 		String invalidValue = "aVal3IsNotAvalidValue";
 		a.setValue(invalidValue);
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				configurer.newLink();
-			}
-		});
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> configurer.newLink());
 		assertThat(exception.getMessage(), is(invalidValue + " is not a valid value for "
-				+ "A is meant just to be an example attribute"
-				+ ", valid values are [aVal1, aVal2]"));
+				+ "A is meant just to be an example attribute" + ", valid values are [aVal1, aVal2]"));
 	}
 
 	@Test
-	public void attributeWithoutChoiceValueThrowsRTE() {
-		Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
-		final ConfigAttribute configAttribute = configurer.getAttribute("c");
+	void attributeWithoutChoiceValueThrowsRTE() {
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
+		ConfigAttribute configAttribute = configurer.getAttribute("c");
 		assertThat(configAttribute.hasChoiceValues(), is(false));
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalStateException exception = assertThrows(IllegalStateException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				configAttribute.getChoiceValues();
-			}
-		});
+		IllegalStateException exception = assertThrows(IllegalStateException.class,
+				() -> configAttribute.getChoiceValues());
 		assertThat(exception.getMessage(), is("attribute does not have choiceValues"));
 	}
 
 	@Test
-	public void canIterateRegisteredFactories() {
-		assertThat(
-				sut.listURIs(),
-				is(links( //
-						"ardulink://dummyLink", //
-						"ardulink://mock", //
-						"ardulink://staticregistry", //
-						"ardulink://aLinkWithoutArealLinkFactoryWithoutConfig", //
-						"ardulink://aLinkWithoutArealLinkFactoryWithConfig" //
-				)));
+	void canIterateRegisteredFactories() {
+		assertThat(sut.listURIs(), is(links( //
+				"ardulink://dummyLink", //
+				"ardulink://mock", //
+				"ardulink://staticregistry", //
+				"ardulink://aLinkWithoutArealLinkFactoryWithoutConfig", //
+				"ardulink://aLinkWithoutArealLinkFactoryWithConfig" //
+		)));
 	}
 
-	@LapsedWith(module = JDK8, value = "Streams")
 	private List<URI> links(String... links) {
-		List<URI> uris = new ArrayList<URI>(links.length);
-		for (String link : links) {
-			uris.add(URIs.newURI(link));
-		}
-		return uris;
+		return Arrays.stream(links).map(URIs::newURI).collect(toList());
 	}
 
 	@Test
-	public void i18n_english() {
+	void i18n_english() {
 		Locale.setDefault(ENGLISH);
-		assertThat(getName("a"),
-				is("A is meant just to be an example attribute"));
+		assertThat(getName("a"), is("A is meant just to be an example attribute"));
 		assertThat(getDescription("a"), is("The description of attribute A"));
 	}
 
 	@Test
-	public void i18n_german() {
+	void i18n_german() {
 		Locale.setDefault(GERMAN);
 		assertThat(getName("a"), is("A ist einfach ein Beispielattribut"));
 		assertThat(getDescription("a"), is("Die Beschreibung für Attribut A"));
 	}
 
 	@Test
-	public void i18n_localeWithoutMessageFileWillFallbackToEnglish() {
+	void i18n_localeWithoutMessageFileWillFallbackToEnglish() {
 		Locale.setDefault(CHINESE);
-		assertThat(getName("a"),
-				is("A is meant just to be an example attribute"));
+		assertThat(getName("a"), is("A is meant just to be an example attribute"));
 		assertThat(getDescription("a"), is("The description of attribute A"));
 	}
 
 	@Test
-	public void i18n_english_untagged_attribute_returns_the_attributes_name() {
+	void i18n_english_untagged_attribute_returns_the_attributes_name() {
 		Locale.setDefault(ENGLISH);
 		assertThat(getName("b"), is("b"));
 	}
 
 	@Test
-	public void hasMinValue() {
-		Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
+	void hasMinValue() {
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
 		ConfigAttribute a = configurer.getAttribute("b");
 		NumberValidationInfo vi = (NumberValidationInfo) a.getValidationInfo();
 		assertThat(((int) vi.min()), is(3));
@@ -300,8 +245,7 @@ public class DummyLinkFactoryTest {
 	}
 
 	private ConfigAttribute getAttribute(String name) {
-		Configurer configurer = sut.getConfigurer(URIs
-				.newURI("ardulink://dummyLink"));
+		Configurer configurer = sut.getConfigurer(URIs.newURI("ardulink://dummyLink"));
 		return configurer.getAttribute(name);
 	}
 

--- a/ardulink-core-base/src/test/java/org/ardulink/core/linkmanager/LinkConfigWithDependentAttributesLinkFactoryTest.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/linkmanager/LinkConfigWithDependentAttributesLinkFactoryTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.mock;
 
 import org.ardulink.core.Link;
 import org.ardulink.core.linkmanager.providers.LinkFactoriesProvider4Test.Statement;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -36,7 +36,7 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class LinkConfigWithDependentAttributesLinkFactoryTest {
+class LinkConfigWithDependentAttributesLinkFactoryTest {
 
 	public static class LinkConfigWithDependentAttributes implements LinkConfig {
 
@@ -101,7 +101,7 @@ public class LinkConfigWithDependentAttributesLinkFactoryTest {
 	}
 
 	@Test
-	public void canInstantiateLinkWithDependentAttributes() throws Exception {
+	void canInstantiateLinkWithDependentAttributes() throws Exception {
 		withRegistered(new LinkConfigWithDependentAttributesLinkFactory()).execute(new Statement() {
 			@Override
 			public void execute() {

--- a/ardulink-core-base/src/test/java/org/ardulink/core/linkmanager/LinkManagerTest.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/linkmanager/LinkManagerTest.java
@@ -28,7 +28,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -46,8 +46,8 @@ import org.ardulink.core.linkmanager.providers.LinkFactoriesProvider4Test.Statem
 import org.ardulink.core.linkmanager.viaservices.AlLinkWithoutArealLinkFactoryWithConfig;
 import org.ardulink.core.linkmanager.viaservices.AlLinkWithoutArealLinkFactoryWithoutConfig;
 import org.ardulink.util.anno.LapsedWith;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -84,7 +84,7 @@ public class LinkManagerTest {
 	LinkManager sut = LinkManager.getInstance();
 
 	@Test
-	public void onceQueriedChoiceValuesStayValid() throws Exception {
+	void onceQueriedChoiceValuesStayValid() throws Exception {
 		Configurer configurer = sut.getConfigurer(newURI("ardulink://dummyLink"));
 
 		choiceValuesOfDNowAre("x", "y");
@@ -108,23 +108,23 @@ public class LinkManagerTest {
 	}
 
 	@Test
-	public void canLoadViaMetaInfServicesArdulinkLinkfactoryWithoutConfig() {
+	void canLoadViaMetaInfServicesArdulinkLinkfactoryWithoutConfig() {
 		Link link = sut.getConfigurer(newURI("ardulink://aLinkWithoutArealLinkFactoryWithoutConfig")).newLink();
 		assertThat(link, is(instanceOf(AlLinkWithoutArealLinkFactoryWithoutConfig.class)));
 	}
 
 	@Test
-	public void canLoadViaMetaInfServicesArdulinkLinkfactoryWithConfig() {
+	void canLoadViaMetaInfServicesArdulinkLinkfactoryWithConfig() {
 		Link link = sut.getConfigurer(newURI("ardulink://aLinkWithoutArealLinkFactoryWithConfig")).newLink();
 		assertThat(link, is(instanceOf(AlLinkWithoutArealLinkFactoryWithConfig.class)));
 	}
 
 	@Test
-	public void nonExistingNameWitllThrowRTE() throws IOException {
+	void nonExistingNameWitllThrowRTE() throws IOException {
 		@LapsedWith(module = JDK8, value = "Lambda")
-		RuntimeException exception = assertThrows(RuntimeException.class, new ThrowingRunnable() {
+		RuntimeException exception = assertThrows(RuntimeException.class, new Executable() {
 			@Override
-			public void run() throws Throwable {
+			public void execute() throws Throwable {
 				sut.getConfigurer(newURI("ardulink://XXX-aNameThatIsNotRegistered-XXX"));
 			}
 		});
@@ -132,7 +132,7 @@ public class LinkManagerTest {
 	}
 
 	@Test
-	public void canLoadDummyLinkViaAlias() throws Exception {
+	void canLoadDummyLinkViaAlias() throws Exception {
 		withRegistered(new AliasUsingLinkFactory()).execute(new Statement() {
 			@Override
 			public void execute() {
@@ -142,7 +142,7 @@ public class LinkManagerTest {
 	}
 
 	@Test
-	public void aliasNameNotListed() throws Exception {
+	void aliasNameNotListed() throws Exception {
 		withRegistered(new AliasUsingLinkFactory()).execute(new Statement() {
 			@Override
 			public void execute() {
@@ -154,7 +154,7 @@ public class LinkManagerTest {
 	}
 
 	@Test
-	public void nameHasPriorityOverAlias() throws Exception {
+	void nameHasPriorityOverAlias() throws Exception {
 		AliasUsingLinkFactory factory = new AliasUsingLinkFactory();
 		final String dummyLinkFactoryName = new DummyLinkFactory().getName();
 		assert aliasNames(factory).contains(dummyLinkFactoryName);

--- a/ardulink-core-base/src/test/java/org/ardulink/core/proto/api/ProtocolsTest.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/proto/api/ProtocolsTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.core.Is.is;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -32,10 +32,10 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class ProtocolsTest {
+class ProtocolsTest {
 
 	@Test
-	public void defaultAndDummyProtocolsAreRegistered() {
+	void defaultAndDummyProtocolsAreRegistered() {
 		assertThat(new HashSet<String>(Protocols.names()),
 				is(new HashSet<String>(Arrays.asList("ardulink2", "dummyProto"))));
 	}

--- a/ardulink-core-base/src/test/java/org/ardulink/core/protong/ArdulinkProtocol2Test.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/protong/ArdulinkProtocol2Test.java
@@ -30,15 +30,15 @@ import org.ardulink.util.Joiner;
 import org.ardulink.util.Lists;
 import org.ardulink.util.MapBuilder;
 import org.ardulink.util.anno.LapsedWith;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ArdulinkProtocol2Test {
+class ArdulinkProtocol2Test {
 
 	private List<FromDeviceMessage> messages;
 	private String message;
 
 	@Test
-	public void canReadAnalogPinViaArdulinkProto() throws IOException {
+	void canReadAnalogPinViaArdulinkProto() throws IOException {
 		int pin = 42;
 		int value = 21;
 		givenMessage(alpProtocolMessage(ANALOG_PIN_READ).forPin(pin).withValue(value));
@@ -47,7 +47,7 @@ public class ArdulinkProtocol2Test {
 	}
 
 	@Test
-	public void canReadDigitalPinViaArdulinkProto() throws IOException {
+	void canReadDigitalPinViaArdulinkProto() throws IOException {
 		int pin = 42;
 		boolean value = true;
 		givenMessage(alpProtocolMessage(DIGITAL_PIN_READ).forPin(pin).withState(value));
@@ -56,7 +56,7 @@ public class ArdulinkProtocol2Test {
 	}
 
 	@Test
-	public void canReadRplyViaArdulinkProto() throws IOException {
+	void canReadRplyViaArdulinkProto() throws IOException {
 		givenMessage("alp://rply/ok?id=1&UniqueID=456-2342-2342&ciao=boo");
 		whenMessageIsProcessed();
 		assertThat(messages.size(), is(1));
@@ -66,7 +66,7 @@ public class ArdulinkProtocol2Test {
 	}
 
 	@Test
-	public void canReadReadyViaArdulinkProto() throws IOException {
+	void canReadReadyViaArdulinkProto() throws IOException {
 		givenMessage("alp://ready/");
 		whenMessageIsProcessed();
 		assertThat(messages.size(), is(1));
@@ -74,7 +74,7 @@ public class ArdulinkProtocol2Test {
 	}
 
 	@Test
-	public void doesRecoverFromMisformedContent() throws IOException {
+	void doesRecoverFromMisformedContent() throws IOException {
 		givenMessages("alp://XXXXXreadyXXXXX/", "alp://ready/");
 		whenMessageIsProcessed();
 		assertThat(messages.size(), is(1));
@@ -82,7 +82,7 @@ public class ArdulinkProtocol2Test {
 	}
 
 	@Test
-	public void ardulinkProtocol2ReceiveCustomEvent() throws IOException {
+	void ardulinkProtocol2ReceiveCustomEvent() throws IOException {
 		givenMessage("alp://cevnt/foo=bar/some=42");
 		whenMessageIsProcessed();
 		assertThat(messages.size(), is(1));
@@ -92,7 +92,7 @@ public class ArdulinkProtocol2Test {
 	}
 
 	@Test
-	public void ardulinkProtocol2ReceiveRply() throws IOException {
+	void ardulinkProtocol2ReceiveRply() throws IOException {
 		long id = 1;
 		Map<String, Object> params = MapBuilder.<String, Object>newMapBuilder().put("UniqueID", "ABC-1234-5678")
 				.put("boo", "ciao").build();

--- a/ardulink-core-base/src/test/java/org/ardulink/core/qos/Arduino.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/core/qos/Arduino.java
@@ -27,7 +27,8 @@ import java.util.regex.Pattern;
 import org.ardulink.core.qos.ArduinoDouble.Adder;
 import org.ardulink.core.qos.ArduinoDouble.RegexAdder;
 import org.ardulink.core.qos.ArduinoDouble.WaitThenDoBuilder;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -37,7 +38,7 @@ import org.junit.rules.ExternalResource;
  * [adsense]
  *
  */
-public class Arduino extends ExternalResource {
+public class Arduino implements AfterEachCallback {
 
 	private final ArduinoDouble arduinoDouble;
 
@@ -56,9 +57,9 @@ public class Arduino extends ExternalResource {
 			throw propagate(e);
 		}
 	}
-
+	
 	@Override
-	protected void after() {
+	public void afterEach(ExtensionContext context) {
 		try {
 			this.arduinoDouble.close();
 		} catch (IOException e) {

--- a/ardulink-core-base/src/test/java/org/ardulink/testsupport/mock/MockLinkFactoryTest.java
+++ b/ardulink-core-base/src/test/java/org/ardulink/testsupport/mock/MockLinkFactoryTest.java
@@ -6,35 +6,35 @@ import static org.hamcrest.core.IsSame.sameInstance;
 
 import org.ardulink.core.Link;
 import org.ardulink.core.convenience.Links;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MockLinkFactoryTest {
+class MockLinkFactoryTest {
 
 	private static final String MOCK_URI = "ardulink://mock";
 
 	@Test
-	public void twoDefaultLinksAreSame() {
+	void twoDefaultLinksAreSame() {
 		Link link1 = Links.getLink(MOCK_URI);
 		Link link2 = Links.getLink(MOCK_URI);
 		assertThat(link1, sameInstance(link2));
 	}
 
 	@Test
-	public void namedNotDefault() {
+	void namedNotDefault() {
 		Link link1 = Links.getLink(MOCK_URI);
 		Link link2 = Links.getLink(MOCK_URI + "?name=another");
 		assertThat(link1, not(sameInstance(link2)));
 	}
 
 	@Test
-	public void defaultNamedIsSameAsDefault() {
+	void defaultNamedIsSameAsDefault() {
 		Link link1 = Links.getLink(MOCK_URI);
 		Link link2 = Links.getLink(MOCK_URI + "?name=default");
 		assertThat(link1, sameInstance(link2));
 	}
 
 	@Test
-	public void differentNameAreDifferentMocks() {
+	void differentNameAreDifferentMocks() {
 		Link link1 = Links.getLink(MOCK_URI + "?name=A");
 		Link link2 = Links.getLink(MOCK_URI + "?name=B");
 		assertThat(link1, not(sameInstance(link2)));

--- a/ardulink-core-beans/pom.xml
+++ b/ardulink-core-beans/pom.xml
@@ -20,9 +20,14 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-core-beans/src/test/java/org/ardulink/core/beans/AnnotationsTest.java
+++ b/ardulink-core-beans/src/test/java/org/ardulink/core/beans/AnnotationsTest.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 
 import org.ardulink.util.anno.LapsedWith;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -23,7 +23,7 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class AnnotationsTest {
+class AnnotationsTest {
 
 	@Retention(RUNTIME)
 	@interface AnotherAnno {
@@ -100,54 +100,46 @@ public class AnnotationsTest {
 	}
 
 	@Test
-	public void anotherAnnoOnTheField() throws Exception {
-		assertHasBothAnnotations(BeanProperties
-				.builder(new AnotherAnnoOnTheField())
-				.using(directFieldAccess()).build());
+	void anotherAnnoOnTheField() throws Exception {
+		assertHasBothAnnotations(
+				BeanProperties.builder(new AnotherAnnoOnTheField()).using(directFieldAccess()).build());
 	}
 
 	@Test
-	public void anotherAnnoOnTheFieldWithGetterAndSetter() throws Exception {
+	void anotherAnnoOnTheFieldWithGetterAndSetter() throws Exception {
 		// this will only work if the property was found using propertyAnnotated
 		// since when looking up via findByIntrospection there is no relation
 		// between the reader/setter and the private field!
-		assertHasBothAnnotations(BeanProperties
-				.builder(new AnotherAnnoOnTheFieldWithGetterAndSetter())
+		assertHasBothAnnotations(BeanProperties.builder(new AnotherAnnoOnTheFieldWithGetterAndSetter())
 				.using(propertyAnnotated(SomeAnno.class)).build());
 	}
 
 	@Test
-	public void testAnnoOnGetter() throws Exception {
-		assertHasBothAnnotations(BeanProperties
-				.forBean(new AnotherAnnoOnTheGetter()));
+	void testAnnoOnGetter() throws Exception {
+		assertHasBothAnnotations(BeanProperties.forBean(new AnotherAnnoOnTheGetter()));
 	}
 
 	@Test
-	public void testAnnoOnSetter() throws Exception {
-		assertHasBothAnnotations(BeanProperties
-				.forBean(new AnotherAnnoOnTheSetter()));
+	void testAnnoOnSetter() throws Exception {
+		assertHasBothAnnotations(BeanProperties.forBean(new AnotherAnnoOnTheSetter()));
 	}
 
 	@Test
-	public void testAnnoOnGetterAndSetter() throws Exception {
-		assertHasBothAnnotations(BeanProperties
-				.forBean(new AnotherAnnoOnTheGetterAndSetter()));
+	void testAnnoOnGetterAndSetter() throws Exception {
+		assertHasBothAnnotations(BeanProperties.forBean(new AnotherAnnoOnTheGetterAndSetter()));
 	}
 
 	@SuppressWarnings("unchecked")
 	private void assertHasBothAnnotations(BeanProperties beanProperties) {
-		hasAnnotations(
-				checkNotNull(beanProperties.getAttribute("string"),
-						"no attribute named \"string\" found in %s",
-						beanProperties), SomeAnno.class, AnotherAnno.class);
+		hasAnnotations(checkNotNull(beanProperties.getAttribute("string"), "no attribute named \"string\" found in %s",
+				beanProperties), SomeAnno.class, AnotherAnno.class);
 	}
 
 	@LapsedWith(module = JDK8, value = "Streams")
-	private void hasAnnotations(Attribute attribute,
-			final Class<? extends Annotation>... annoClasses) {
+	private void hasAnnotations(Attribute attribute, final Class<? extends Annotation>... annoClasses) {
 		for (int i = 0; i < annoClasses.length; i++) {
-			assertThat(annoClasses[i].getSimpleName() + " not found",
-					attribute.getAnnotation(annoClasses[i]), is(notNullValue()));
+			assertThat(annoClasses[i].getSimpleName() + " not found", attribute.getAnnotation(annoClasses[i]),
+					is(notNullValue()));
 		}
 	}
 

--- a/ardulink-core-beans/src/test/java/org/ardulink/core/beans/BeanPropertiesTest.java
+++ b/ardulink-core-beans/src/test/java/org/ardulink/core/beans/BeanPropertiesTest.java
@@ -20,13 +20,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.ardulink.core.beans.finder.impl.FindByAnnotation.propertyAnnotated;
 import static org.ardulink.core.beans.finder.impl.FindByFieldAccess.directFieldAccess;
 import static org.ardulink.core.beans.finder.impl.FindByIntrospection.beanAttributes;
-import static org.ardulink.util.anno.LapsedWith.JDK8;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.annotation.Retention;
 import java.util.ArrayList;
@@ -34,9 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.ardulink.util.anno.LapsedWith;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -46,7 +43,7 @@ import org.junit.function.ThrowingRunnable;
  * [adsense]
  *
  */
-public class BeanPropertiesTest {
+class BeanPropertiesTest {
 
 	@Retention(RUNTIME)
 	public @interface ThisAnnotationHasNoValueAttribute {
@@ -61,6 +58,7 @@ public class BeanPropertiesTest {
 	@Retention(RUNTIME)
 	public @interface OurOwnTestAnno {
 		String value();
+
 		String someOtherAttribute() default "";
 	}
 
@@ -155,14 +153,14 @@ public class BeanPropertiesTest {
 	}
 
 	@Test
-	public void nonExistingProperty() {
+	void nonExistingProperty() {
 		BeanProperties bp = BeanProperties.forBean(new BeanWithReadMethod());
 		Attribute attribute = bp.getAttribute("aNonExisitingAttribute");
 		assertThat(attribute, is(nullValue()));
 	}
 
 	@Test
-	public void canFindPropertyByReadMethod() {
+	void canFindPropertyByReadMethod() {
 		BeanProperties bp = BeanProperties.forBean(new BeanWithReadMethod());
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
@@ -170,7 +168,7 @@ public class BeanPropertiesTest {
 	}
 
 	@Test
-	public void canFindPropertyByWriteMethod() {
+	void canFindPropertyByWriteMethod() {
 		BeanProperties bp = BeanProperties.forBean(new BeanWithWriteMethod());
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
@@ -178,7 +176,7 @@ public class BeanPropertiesTest {
 	}
 
 	@Test
-	public void canReadValue() throws Exception {
+	void canReadValue() throws Exception {
 		String value = "bar";
 		BeanWithReadAndWriteMethod bean = new BeanWithReadAndWriteMethod();
 		bean.setFoo(value);
@@ -189,10 +187,9 @@ public class BeanPropertiesTest {
 	}
 
 	@Test
-	public void canWriteValue() throws Exception {
+	void canWriteValue() throws Exception {
 		String value = "bar";
-		BeanProperties bp = BeanProperties
-				.forBean(new BeanWithReadAndWriteMethod());
+		BeanProperties bp = BeanProperties.forBean(new BeanWithReadAndWriteMethod());
 		Attribute attribute = bp.getAttribute("foo");
 		attribute.writeValue("bar");
 		assertThat(attribute.getName(), is("foo"));
@@ -200,64 +197,46 @@ public class BeanPropertiesTest {
 	}
 
 	@Test
-	public void canFindPropertyByAnnotatedReadMethod() {
-		BeanProperties bp = BeanProperties
-				.builder(new BeanWithAnnotatedReadMethod())
-				.using(beanAttributes(),
-						propertyAnnotated(OurOwnTestAnno.class)).build();
+	void canFindPropertyByAnnotatedReadMethod() {
+		BeanProperties bp = BeanProperties.builder(new BeanWithAnnotatedReadMethod())
+				.using(beanAttributes(), propertyAnnotated(OurOwnTestAnno.class)).build();
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
 		assertThat(attribute.getType().getName(), is(String.class.getName()));
 	}
 
 	@Test
-	public void canFindPropertyByAnnotatedWriteMethod() {
-		BeanProperties bp = BeanProperties
-				.builder(new BeanWithAnnotatedWriteMethod())
-				.using(beanAttributes(),
-						propertyAnnotated(OurOwnTestAnno.class)).build();
+	void canFindPropertyByAnnotatedWriteMethod() {
+		BeanProperties bp = BeanProperties.builder(new BeanWithAnnotatedWriteMethod())
+				.using(beanAttributes(), propertyAnnotated(OurOwnTestAnno.class)).build();
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
 		assertThat(attribute.getType().getName(), is(String.class.getName()));
 	}
 
 	@Test
-	public void throwsExceptionsIfAnnotationHasNoValueAttribute() {
-		final Class<ThisAnnotationHasNoValueAttribute> clazz = ThisAnnotationHasNoValueAttribute.class;
-		
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				propertyAnnotated(clazz);
-			}
-		});
-		assertThat(exception.getMessage(), allOf(containsString(clazz.getName()),
-				containsString("has no attribute named value")));
+	void throwsExceptionsIfAnnotationHasNoValueAttribute() {
+		Class<ThisAnnotationHasNoValueAttribute> clazz = ThisAnnotationHasNoValueAttribute.class;
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> propertyAnnotated(clazz));
+		assertThat(exception.getMessage(),
+				allOf(containsString(clazz.getName()), containsString("has no attribute named value")));
 	}
 
 	@Test
-	public void throwsExceptionsIfAnnotationHasValueAttributeWithWrongType() {
-		final Class<ThisAnnotationHasAnAttributeThatIsNotAstring> clazz = ThisAnnotationHasAnAttributeThatIsNotAstring.class;
-		
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				propertyAnnotated(clazz);
-			}
-		});
+	void throwsExceptionsIfAnnotationHasValueAttributeWithWrongType() {
+		Class<ThisAnnotationHasAnAttributeThatIsNotAstring> clazz = ThisAnnotationHasAnAttributeThatIsNotAstring.class;
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> propertyAnnotated(clazz));
 		assertThat(exception.getMessage(), allOf(containsString(clazz.getName()),
-				containsString(String.class.getName()),
-				containsString(boolean.class.getName())));
+				containsString(String.class.getName()), containsString(boolean.class.getName())));
 	}
 
 	@Test
-	public void canDirectlyAccessFields() throws Exception {
+	void canDirectlyAccessFields() throws Exception {
 		String value = "bar";
 		BeanWithPublicField bean = new BeanWithPublicField();
-		BeanProperties bp = BeanProperties.builder(bean)
-				.using(directFieldAccess()).build();
+		BeanProperties bp = BeanProperties.builder(bean).using(directFieldAccess()).build();
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
 		assertThat(attribute.getType().getName(), is(String.class.getName()));
@@ -266,63 +245,51 @@ public class BeanPropertiesTest {
 	}
 
 	@Test
-	public void canMergeDifferentTypes() throws Exception {
-		BeanProperties bp = BeanProperties
-				.builder(new BeanWithDifferentTypes())
+	void canMergeDifferentTypes() throws Exception {
+		BeanProperties bp = BeanProperties.builder(new BeanWithDifferentTypes())
 				.using(propertyAnnotated(OurOwnTestAnno.class)).build();
-		Attribute attribute = bp
-				.getAttribute("weHaveToUseAnnotationsSinceThisWontWorkWithBeans");
-		assertThat(attribute.getType().getName(),
-				is(Collection.class.getName()));
+		Attribute attribute = bp.getAttribute("weHaveToUseAnnotationsSinceThisWontWorkWithBeans");
+		assertThat(attribute.getType().getName(), is(Collection.class.getName()));
 	}
 
 	@Test
-	public void canlistAttributes() {
-		BeanProperties bp = BeanProperties
-				.forBean(new BeanWithMultipleAttributes());
-		assertThat(new ArrayList<String>(bp.attributeNames()),
-				is(Arrays.asList("a", "b")));
+	void canlistAttributes() {
+		BeanProperties bp = BeanProperties.forBean(new BeanWithMultipleAttributes());
+		assertThat(new ArrayList<String>(bp.attributeNames()), is(Arrays.asList("a", "b")));
 	}
 
 	@Test
-	public void canFindPropertyByAnnotatedField() throws Exception {
+	void canFindPropertyByAnnotatedField() throws Exception {
 		BeanWithSettersAndGettersAndAnnoOnPrivateField bean = new BeanWithSettersAndGettersAndAnnoOnPrivateField();
-		BeanProperties bp = BeanProperties.builder(bean)
-				.using(propertyAnnotated(OurOwnTestAnno.class)).build();
+		BeanProperties bp = BeanProperties.builder(bean).using(propertyAnnotated(OurOwnTestAnno.class)).build();
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
 		assertThat(attribute.getType().getName(), is(List.class.getName()));
 		attribute.writeValue(Arrays.asList("1", "2", "3"));
 		assertThat(bean.getValues(), is(Arrays.asList("1", "2", "3")));
 		bean.setValues(Arrays.asList("3", "2", "1"));
-		assertThat(attribute.readValue(),
-				is((Object) Arrays.asList("3", "2", "1")));
+		assertThat(attribute.readValue(), is((Object) Arrays.asList("3", "2", "1")));
 	}
 
 	@Test
-	public void canFindPropertyByAnnotatedPublicField() throws Exception {
+	void canFindPropertyByAnnotatedPublicField() throws Exception {
 		BeanWithAnnoOnPublicField bean = new BeanWithAnnoOnPublicField();
-		BeanProperties bp = BeanProperties
-				.builder(bean)
-				.using(beanAttributes(),
-						propertyAnnotated(OurOwnTestAnno.class)).build();
+		BeanProperties bp = BeanProperties.builder(bean)
+				.using(beanAttributes(), propertyAnnotated(OurOwnTestAnno.class)).build();
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
 		assertThat(attribute.getType().getName(), is(List.class.getName()));
 		attribute.writeValue(Arrays.asList("1", "2", "3"));
 		assertThat(bean.values, is(Arrays.asList("1", "2", "3")));
 		bean.values = Arrays.asList("3", "2", "1");
-		assertThat(attribute.readValue(),
-				is((Object) Arrays.asList("3", "2", "1")));
+		assertThat(attribute.readValue(), is((Object) Arrays.asList("3", "2", "1")));
 	}
 
 	@Test
-	public void canFindPropertyByAnnotatedPublicFieldBitNotUsingValueButSomeOtherAttribute() throws Exception {
+	void canFindPropertyByAnnotatedPublicFieldBitNotUsingValueButSomeOtherAttribute() throws Exception {
 		BeanWithAnnoOnPublicFieldButUsingNotValueButSomeOtherAttribute bean = new BeanWithAnnoOnPublicFieldButUsingNotValueButSomeOtherAttribute();
-		BeanProperties bp = BeanProperties
-				.builder(bean)
-				.using(beanAttributes(),
-						propertyAnnotated(OurOwnTestAnno.class, "someOtherAttribute")).build();
+		BeanProperties bp = BeanProperties.builder(bean)
+				.using(beanAttributes(), propertyAnnotated(OurOwnTestAnno.class, "someOtherAttribute")).build();
 		Attribute attribute = bp.getAttribute("foo");
 		assertThat(attribute.getName(), is("foo"));
 		assertThat(attribute.getType().getName(), is(List.class.getName()));

--- a/ardulink-core-bluetooth/pom.xml
+++ b/ardulink-core-bluetooth/pom.xml
@@ -9,12 +9,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -27,9 +21,14 @@
 			<version>2.1.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-core-digispark/pom.xml
+++ b/ardulink-core-digispark/pom.xml
@@ -9,12 +9,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -27,9 +21,14 @@
 			<version>0.5.9</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-core-firmata-proto/pom.xml
+++ b/ardulink-core-firmata-proto/pom.xml
@@ -22,9 +22,14 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.github.kurbatov</groupId>

--- a/ardulink-core-firmata-proto/src/test/java/org/ardulink/core/protong/impl/FirmataProtocolTest.java
+++ b/ardulink-core-firmata-proto/src/test/java/org/ardulink/core/protong/impl/FirmataProtocolTest.java
@@ -26,15 +26,15 @@ import org.ardulink.core.proto.impl.FirmataProtocol;
 import org.ardulink.util.Lists;
 import org.ardulink.util.MapBuilder;
 import org.ardulink.util.anno.LapsedWith;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class FirmataProtocolTest {
+class FirmataProtocolTest {
 
 	private byte[] bytes;
 	private List<FromDeviceMessage> messages;
 
 	@Test
-	public void canReadAnalogPinViaFirmataProto() throws IOException {
+	void canReadAnalogPinViaFirmataProto() throws IOException {
 		byte command = ANALOG_MESSAGE;
 		byte pin = 15;
 		byte valueLow = 127;
@@ -45,7 +45,7 @@ public class FirmataProtocolTest {
 	}
 
 	@Test
-	public void canReadDigitalPinViaFirmataProto() throws IOException {
+	void canReadDigitalPinViaFirmataProto() throws IOException {
 		byte command = DIGITAL_MESSAGE;
 		byte port = 4;
 		byte valueLow = binary("010" + "0101");

--- a/ardulink-core-mqtt/pom.xml
+++ b/ardulink-core-mqtt/pom.xml
@@ -10,12 +10,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -37,9 +31,14 @@
 			<version>1.16</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.ardulink</groupId>

--- a/ardulink-core-mqtt/src/test/java/org/ardulink/core/mqtt/I18NTest.java
+++ b/ardulink-core-mqtt/src/test/java/org/ardulink/core/mqtt/I18NTest.java
@@ -2,12 +2,12 @@ package org.ardulink.core.mqtt;
 
 import static org.ardulink.testsupport.i18n.I18NTestSupport.assertAllAttributesHaveDescriptions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class I18NTest {
+class I18NTest {
 
 	@Test
-	public void allAttributesHaveAdescription() {
+	void allAttributesHaveAdescription() {
 		assertAllAttributesHaveDescriptions("ardulink://mqtt");
 	}
 

--- a/ardulink-core-mqtt/src/test/java/org/ardulink/core/mqtt/MqttWithAuthenticationIntegrationTest.java
+++ b/ardulink-core-mqtt/src/test/java/org/ardulink/core/mqtt/MqttWithAuthenticationIntegrationTest.java
@@ -16,23 +16,19 @@ limitations under the License.
 
 package org.ardulink.core.mqtt;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.ardulink.util.anno.LapsedWith.JDK8;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.URI;
 
 import org.ardulink.core.linkmanager.LinkManager;
 import org.ardulink.util.URIs;
-import org.ardulink.util.anno.LapsedWith;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -42,29 +38,27 @@ import org.junit.rules.Timeout;
  * [adsense]
  *
  */
-public class MqttWithAuthenticationIntegrationTest {
+@Timeout(30)
+class MqttWithAuthenticationIntegrationTest {
 
-	private static final String USER = "user";
+	static final String USER = "user";
 
-	private static final String PASSWORD = "pass";
+	static final String PASSWORD = "pass";
 
-	private static final String TOPIC = "myTopic" + System.currentTimeMillis();
+	static final String TOPIC = "myTopic" + System.currentTimeMillis();
 
-	@Rule
-	public Broker broker = Broker.newBroker().authentication(USER + ":" + PASSWORD);
-
-	@Rule
-	public Timeout timeout = new Timeout(30, SECONDS);
+	@RegisterExtension
+	Broker broker = Broker.newBroker().authentication(USER + ":" + PASSWORD);
 
 	@Test
-	public void canNotConnectWithoutUserAndPassword() {
+	void canNotConnectWithoutUserAndPassword() {
 		Exception exception = createLinkAndCatchRTE(URIs.newURI("ardulink://mqtt?topic=" + TOPIC));
 		assertThat(exception.getMessage(), is(allOf(containsString("BAD"), containsString("USERNAME"),
 				containsString("OR"), containsString("PASSWORD"))));
 	}
 
 	@Test
-	public void canNotConnectWithWrongPassword() {
+	void canNotConnectWithWrongPassword() {
 		Exception exception = createLinkAndCatchRTE(
 				URIs.newURI("ardulink://mqtt?user=" + USER + "&password=" + "anyWrongPassword" + "&topic=" + TOPIC));
 		assertThat(exception.getMessage(), is(allOf(containsString("BAD"), containsString("USERNAME"),
@@ -72,18 +66,12 @@ public class MqttWithAuthenticationIntegrationTest {
 	}
 
 	@Test
-	public void canConnectUsingUserAndPassword() {
+	void canConnectUsingUserAndPassword() {
 		createLink(URIs.newURI("ardulink://mqtt?user=" + USER + "&password=" + PASSWORD + "&topic=" + TOPIC));
 	}
 
-	@LapsedWith(module = JDK8, value = "Lambda")
 	private static RuntimeException createLinkAndCatchRTE(final URI uri) {
-		return assertThrows(RuntimeException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				createLink(uri);
-			}
-		});
+		return assertThrows(RuntimeException.class, () -> createLink(uri));
 	}
 
 	private static void createLink(URI uri) {

--- a/ardulink-core-nodemcu/pom.xml
+++ b/ardulink-core-nodemcu/pom.xml
@@ -9,12 +9,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -31,9 +25,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-core-nodemcu/src/test/java/org/ardulink/core/proto/impl/LuaProtoTest.java
+++ b/ardulink-core-nodemcu/src/test/java/org/ardulink/core/proto/impl/LuaProtoTest.java
@@ -34,9 +34,9 @@ import org.ardulink.core.messages.impl.DefaultToDeviceMessagePinStateChange;
 import org.ardulink.core.messages.impl.DefaultToDeviceMessageStartListening;
 import org.ardulink.core.proto.api.bytestreamproccesors.ByteStreamProcessor;
 import org.ardulink.util.Joiner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class LuaProtoTest {
+class LuaProtoTest {
 
 	private final ByteStreamProcessor sut = LuaProtocol.instance().newByteStreamProcessor();
 
@@ -45,43 +45,35 @@ public class LuaProtoTest {
 	private final int anyValue = anyIntValue();
 
 	@Test
-	public void generatePowerPinSwitchMessageHigh() {
-		ToDeviceMessagePinStateChange msg = new DefaultToDeviceMessagePinStateChange(
-				anyDigitalPin, true);
-		assertThat(stringOf(sut.toDevice(msg)),
-				is(lua(powerPinMessage(anyDigitalPin.pinNum(), "HIGH"))));
+	void generatePowerPinSwitchMessageHigh() {
+		ToDeviceMessagePinStateChange msg = new DefaultToDeviceMessagePinStateChange(anyDigitalPin, true);
+		assertThat(stringOf(sut.toDevice(msg)), is(lua(powerPinMessage(anyDigitalPin.pinNum(), "HIGH"))));
 	}
 
 	@Test
-	public void generatePowerPinSwitchMessageLow() {
-		ToDeviceMessagePinStateChange msg = new DefaultToDeviceMessagePinStateChange(
-				anyDigitalPin, false);
-		assertThat(stringOf(sut.toDevice(msg)),
-				is(lua(powerPinMessage(anyDigitalPin.pinNum(), "LOW"))));
+	void generatePowerPinSwitchMessageLow() {
+		ToDeviceMessagePinStateChange msg = new DefaultToDeviceMessagePinStateChange(anyDigitalPin, false);
+		assertThat(stringOf(sut.toDevice(msg)), is(lua(powerPinMessage(anyDigitalPin.pinNum(), "LOW"))));
 	}
 
 	@Test
-	public void generatePowerPinIntensityMessage() {
-		ToDeviceMessagePinStateChange msg = new DefaultToDeviceMessagePinStateChange(
-				anyAnalogPin, anyValue);
-		assertThat(stringOf(sut.toDevice(msg)),
-				is(lua(pinStateChangeMessage(anyAnalogPin.pinNum(), anyValue))));
+	void generatePowerPinIntensityMessage() {
+		ToDeviceMessagePinStateChange msg = new DefaultToDeviceMessagePinStateChange(anyAnalogPin, anyValue);
+		assertThat(stringOf(sut.toDevice(msg)), is(lua(pinStateChangeMessage(anyAnalogPin.pinNum(), anyValue))));
 	}
 
 	@Test
-	public void generateCustomMessage() {
+	void generateCustomMessage() {
 		String[] values = new String[] { "param1", "somethingelse2", "final3" };
 		ToDeviceMessageCustom msg = new DefaultToDeviceMessageCustom(values);
 		assertThat(stringOf(sut.toDevice(msg)), is(lua(customMessage(values))));
 	}
 
 	@Test
-	public void generateStartListeningDigitalMessage() {
+	void generateStartListeningDigitalMessage() {
 		DigitalPin pin = digitalPin(anyPin());
-		ToDeviceMessageStartListening msg = new DefaultToDeviceMessageStartListening(
-				pin);
-		assertThat(stringOf(sut.toDevice(msg)), containsString("alp://dred/"
-				+ pin.pinNum() + "/%s"));
+		ToDeviceMessageStartListening msg = new DefaultToDeviceMessageStartListening(pin);
+		assertThat(stringOf(sut.toDevice(msg)), containsString("alp://dred/" + pin.pinNum() + "/%s"));
 	}
 
 	private String stringOf(byte[] bytes) {
@@ -93,15 +85,11 @@ public class LuaProtoTest {
 	}
 
 	private static String powerPinMessage(int pin, String state) {
-		return String.format(
-				"gpio.mode(%s,gpio.OUTPUT) gpio.write(%s,gpio.%s)", pin, pin,
-				state);
+		return String.format("gpio.mode(%s,gpio.OUTPUT) gpio.write(%s,gpio.%s)", pin, pin, state);
 	}
 
 	private static String pinStateChangeMessage(int pin, int value) {
-		return String.format(
-				"pwm.setup(%s,1000,1023) pwm.start(%s) pwm.setduty(%s,%s)",
-				pin, pin, pin, value);
+		return String.format("pwm.setup(%s,1000,1023) pwm.start(%s) pwm.setduty(%s,%s)", pin, pin, pin, value);
 	}
 
 	private String customMessage(String[] values) {

--- a/ardulink-core-proxy/pom.xml
+++ b/ardulink-core-proxy/pom.xml
@@ -9,12 +9,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -31,9 +25,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-core-proxy/src/test/java/org/ardulink/core/proxy/ProxyServerDouble.java
+++ b/ardulink-core-proxy/src/test/java/org/ardulink/core/proxy/ProxyServerDouble.java
@@ -33,7 +33,9 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.ardulink.util.Lists;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * [adsense]
  *
  */
-public class ProxyServerDouble extends ExternalResource {
+public class ProxyServerDouble implements BeforeEachCallback, AfterEachCallback{
 
 	private static final Logger logger = LoggerFactory
 			.getLogger(ProxyServerDouble.class);
@@ -102,13 +104,14 @@ public class ProxyServerDouble extends ExternalResource {
 		};
 	}
 
+	
 	@Override
-	protected void before() {
+	public void beforeEach(ExtensionContext context) {
 		this.thread.start();
 	}
 
 	@Override
-	protected void after() {
+	public void afterEach(ExtensionContext context) {
 		this.thread.interrupt();
 		try {
 			this.serverSocket.close();
@@ -119,7 +122,7 @@ public class ProxyServerDouble extends ExternalResource {
 	
 	public static void main(String[] args) throws InterruptedException {
 		ProxyServerDouble serverDouble = new ProxyServerDouble(newSocket(4478));
-		serverDouble.before();
+		serverDouble.beforeEach(null);
 		serverDouble.thread.join();
 	}
 

--- a/ardulink-core-raspberry/pom.xml
+++ b/ardulink-core-raspberry/pom.xml
@@ -9,13 +9,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<!-- pi4j depends on Java7 -->
-	<properties>
-		<compilerVersion>1.7</compilerVersion>
-		<maven.compiler.source>1.7</maven.compiler.source>
-		<maven.compiler.target>1.7</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -28,9 +21,14 @@
 			<version>1.3</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-core-raspberry/src/test/java/org/ardulink/core/raspi/PiLinkTest.java
+++ b/ardulink-core-raspberry/src/test/java/org/ardulink/core/raspi/PiLinkTest.java
@@ -16,13 +16,10 @@ limitations under the License.
 
 package org.ardulink.core.raspi;
 
-import static org.ardulink.util.anno.LapsedWith.JDK8;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.ardulink.core.convenience.Links;
-import org.ardulink.util.anno.LapsedWith;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -32,19 +29,11 @@ import org.junit.function.ThrowingRunnable;
  * [adsense]
  *
  */
-public class PiLinkTest {
+class PiLinkTest {
 
 	@Test
-	// TODO should do a Assume if we are on a raspi or not
-	public void creatingInstanceWillFailOnX86withUnsatisfiedLinkError() {
-		@LapsedWith(module = JDK8, value = "Lambda")
-		ThrowingRunnable runnable = new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				Links.getLink("ardulink://raspberry");
-			}
-		};
-		assertThrows(UnsatisfiedLinkError.class, runnable);
+	void creatingInstanceWillFailOnX86withUnsatisfiedLinkError() {
+		assertThrows(UnsatisfiedLinkError.class, () -> Links.getLink("ardulink://raspberry"));
 	}
 
 }

--- a/ardulink-core-serial-jssc/pom.xml
+++ b/ardulink-core-serial-jssc/pom.xml
@@ -10,12 +10,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -37,9 +31,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.ardulink</groupId>

--- a/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/I18NTest.java
+++ b/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/I18NTest.java
@@ -2,12 +2,12 @@ package org.ardulink.core.serial.jssc;
 
 import static org.ardulink.testsupport.i18n.I18NTestSupport.assertAllAttributesHaveDescriptions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class I18NTest {
+class I18NTest {
 
 	@Test
-	public void allAttributesHaveAdescription() {
+	void allAttributesHaveAdescription() {
 		assertAllAttributesHaveDescriptions("ardulink://serial-jssc");
 	}
 

--- a/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/RealConnectionListenTest.java
+++ b/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/RealConnectionListenTest.java
@@ -10,17 +10,17 @@ import org.ardulink.core.linkmanager.LinkManager;
 import org.ardulink.core.linkmanager.LinkManager.ConfigAttribute;
 import org.ardulink.core.linkmanager.LinkManager.Configurer;
 import org.ardulink.util.URIs;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-@Ignore
-public class RealConnectionListenTest {
-	
+@Disabled
+class RealConnectionListenTest {
+
 	private Link link;
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		Configurer configurer = LinkManager.getInstance().getConfigurer(URIs.newURI("ardulink://serial-jssc/"));
 
 		ConfigAttribute portAttribute = configurer.getAttribute("port");
@@ -29,15 +29,15 @@ public class RealConnectionListenTest {
 
 		ConfigAttribute pingprobeAttribute = configurer.getAttribute("pingprobe");
 		pingprobeAttribute.setValue(false);
-		
+
 		link = configurer.newLink();
 	}
-	
+
 	@Test
-	public void listen() throws IOException, InterruptedException {
-		
+	void listen() throws IOException, InterruptedException {
+
 		link.addCustomListener(new CustomListener() {
-			
+
 			@Override
 			public void customEventReceived(CustomEvent e) {
 				System.out.println(e.getMessage());
@@ -49,40 +49,29 @@ public class RealConnectionListenTest {
 
 }
 
-/* this is the sketch you can use
+/*
+ * this is the sketch you can use
  * 
-
-String inputString = "";         // a string to hold incoming data (Ardulink)
-boolean stringComplete = false;  // whether the string is complete (Ardulink)
-
-// print data to serial port 
-void dataPrint(unsigned long Count, int Temperature){
-  Serial.print("alp://cevnt/");
-  Serial.print("RAWMONITOR");
-  Serial.print(Count);
-  Serial.print("_");
-  Serial.print(Temperature);
-  Serial.print('\n');
-  Serial.flush();
-}
-
-// QCM frequency by counting the number of pulses in a fixed time 
-unsigned long frequency = 0;
-// thermistor temperature
-int temperature = 0;
-
-void setup(){
-  Serial.begin(115200);
-  while(!Serial); // Wait until Serial not connected (because difference between Leonardo and Micro with UNO and others)
-}
-
-void loop(){
-  frequency = 20;       // measure QCM frequency
-  temperature = 10;     // measure temperature 
-  dataPrint(frequency, temperature);  // print data
-  delay(1000);
-}
-
+ * 
+ * String inputString = ""; // a string to hold incoming data (Ardulink) boolean
+ * stringComplete = false; // whether the string is complete (Ardulink)
+ * 
+ * // print data to serial port void dataPrint(unsigned long Count, int
+ * Temperature){ Serial.print("alp://cevnt/"); Serial.print("RAWMONITOR");
+ * Serial.print(Count); Serial.print("_"); Serial.print(Temperature);
+ * Serial.print('\n'); Serial.flush(); }
+ * 
+ * // QCM frequency by counting the number of pulses in a fixed time unsigned
+ * long frequency = 0; // thermistor temperature int temperature = 0;
+ * 
+ * void setup(){ Serial.begin(115200); while(!Serial); // Wait until Serial not
+ * connected (because difference between Leonardo and Micro with UNO and others)
+ * }
+ * 
+ * void loop(){ frequency = 20; // measure QCM frequency temperature = 10; //
+ * measure temperature dataPrint(frequency, temperature); // print data
+ * delay(1000); }
  *
  *
+ * 
  */

--- a/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/SerialLinkFactoryIntegrationTest.java
+++ b/ardulink-core-serial-jssc/src/test/java/org/ardulink/core/serial/jssc/connectionmanager/SerialLinkFactoryIntegrationTest.java
@@ -19,13 +19,12 @@ package org.ardulink.core.serial.jssc.connectionmanager;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.ardulink.util.Lists.newArrayList;
-import static org.ardulink.util.anno.LapsedWith.JDK8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assume.assumeThat;
+import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Map;
@@ -40,10 +39,8 @@ import org.ardulink.core.linkmanager.LinkManager;
 import org.ardulink.core.linkmanager.LinkManager.ConfigAttribute;
 import org.ardulink.core.linkmanager.LinkManager.Configurer;
 import org.ardulink.util.URIs;
-import org.ardulink.util.anno.LapsedWith;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import jssc.SerialPortList;
 
@@ -55,14 +52,14 @@ import jssc.SerialPortList;
  * [adsense]
  *
  */
-public class SerialLinkFactoryIntegrationTest {
-	
+class SerialLinkFactoryIntegrationTest {
+
 	private Link link;
-	
+
 	@Test
-	public void canConfigureSerialConnectionViaURI() throws Exception {
+	void canConfigureSerialConnectionViaURI() throws Exception {
 		String[] portNames = SerialPortList.getPortNames();
-		assumeThat(portNames.length > 0, is(TRUE));
+		assumeTrue(portNames.length > 0);
 
 		LinkManager connectionManager = LinkManager.getInstance();
 		Configurer configurer = connectionManager.getConfigurer(URIs
@@ -73,7 +70,7 @@ public class SerialLinkFactoryIntegrationTest {
 	}
 
 	@Test
-	public void canConfigureSerialConnectionViaConfigurer() {
+	void canConfigureSerialConnectionViaConfigurer() {
 		LinkManager connectionManager = LinkManager.getInstance();
 		Configurer configurer = connectionManager.getConfigurer(URIs.newURI("ardulink://serial-jssc"));
 
@@ -93,10 +90,11 @@ public class SerialLinkFactoryIntegrationTest {
 		port.setValue("anyString");
 		baudrate.setValue(115200);
 	}
-	
+
 	@Test
-	@Ignore
-	public void connectionListeningTest() throws IOException, InterruptedException {
+	@Disabled
+
+	void connectionListeningTest() throws IOException, InterruptedException {
 		Configurer configurer = LinkManager.getInstance().getConfigurer(URIs.newURI("ardulink://serial-jssc/"));
 
 		ConfigAttribute portAttribute = configurer.getAttribute("port");
@@ -105,23 +103,23 @@ public class SerialLinkFactoryIntegrationTest {
 
 		ConfigAttribute pingprobeAttribute = configurer.getAttribute("pingprobe");
 		pingprobeAttribute.setValue(false);
-		
+
 		link = configurer.newLink();
-		
+
 		link.addRplyListener(new RplyListener() {
-			
+
 			@Override
 			public void rplyReceived(RplyEvent e) {
 				Map<String, Object> parameters = e.getParameters();
 				for (String key : parameters.keySet()) {
 					System.out.println(key + "=" + parameters.get(key));
 				}
-				
+
 			}
 		});
-		
+
 		link.addCustomListener(new CustomListener() {
-			
+
 			@Override
 			public void customEventReceived(CustomEvent e) {
 				System.out.println(e.getMessage());
@@ -129,28 +127,19 @@ public class SerialLinkFactoryIntegrationTest {
 		});
 
 		TimeUnit.SECONDS.sleep(10);
-		
+
 		sendCustom();
-		
+
 		TimeUnit.SECONDS.sleep(10);
-		
+
 		link.close();
 	}
-	
+
 	@Test
-	public void cantConnectWithoutPort() {
+	void cantConnectWithoutPort() {
 		LinkManager connectionManager = LinkManager.getInstance();
-		final Configurer configurer = connectionManager
-				.getConfigurer(URIs.newURI("ardulink://serial-jssc?baudrate=9600"));
-		
-		@LapsedWith(module = JDK8, value = "Lambda")
-		ThrowingRunnable runnable = new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				configurer.newLink();
-			}
-		};
-		assertThrows(RuntimeException.class, runnable);
+		Configurer configurer = connectionManager.getConfigurer(URIs.newURI("ardulink://serial-jssc?baudrate=9600"));
+		assertThrows(RuntimeException.class, () -> configurer.newLink());
 	}
 
 	public void sendCustom() throws IOException {

--- a/ardulink-core-serial-nrrxtx/pom.xml
+++ b/ardulink-core-serial-nrrxtx/pom.xml
@@ -10,12 +10,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -37,9 +31,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.ardulink</groupId>

--- a/ardulink-core-serial-rxtx/pom.xml
+++ b/ardulink-core-serial-rxtx/pom.xml
@@ -10,12 +10,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<maven.compiler.target>1.6</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -37,9 +31,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.ardulink</groupId>

--- a/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/I18NTest.java
+++ b/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/I18NTest.java
@@ -2,12 +2,12 @@ package org.ardulink.core.serial.rxtx;
 
 import static org.ardulink.testsupport.i18n.I18NTestSupport.assertAllAttributesHaveDescriptions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class I18NTest {
+class I18NTest {
 
 	@Test
-	public void allAttributesHaveAdescription() {
+	void allAttributesHaveAdescription() {
 		assertAllAttributesHaveDescriptions("ardulink://serial-rxtx");
 	}
 

--- a/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/connectionmanager/SerialLinkFactoryIntegrationTest.java
+++ b/ardulink-core-serial-rxtx/src/test/java/org/ardulink/core/serial/rxtx/connectionmanager/SerialLinkFactoryIntegrationTest.java
@@ -19,22 +19,19 @@ package org.ardulink.core.serial.rxtx.connectionmanager;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.ardulink.util.Lists.newArrayList;
-import static org.ardulink.util.anno.LapsedWith.JDK8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.ardulink.core.linkmanager.LinkManager;
 import org.ardulink.core.linkmanager.LinkManager.ConfigAttribute;
 import org.ardulink.core.linkmanager.LinkManager.Configurer;
 import org.ardulink.util.URIs;
-import org.ardulink.util.anno.LapsedWith;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -45,11 +42,11 @@ import org.junit.function.ThrowingRunnable;
  *
  */
 // because JNI dependent
-@Ignore
-public class SerialLinkFactoryIntegrationTest {
+@Disabled
+class SerialLinkFactoryIntegrationTest {
 
 	@Test
-	public void canConfigureSerialConnectionViaURI() throws Exception {
+	void canConfigureSerialConnectionViaURI() throws Exception {
 		LinkManager connectionManager = LinkManager.getInstance();
 		Configurer configurer = connectionManager
 				.getConfigurer(URIs.newURI("ardulink://serial?port=anyString&baudrate=9600"));
@@ -57,7 +54,7 @@ public class SerialLinkFactoryIntegrationTest {
 	}
 
 	@Test
-	public void canConfigureSerialConnectionViaConfigurer() {
+	void canConfigureSerialConnectionViaConfigurer() {
 		LinkManager connectionManager = LinkManager.getInstance();
 		Configurer configurer = connectionManager.getConfigurer(URIs.newURI("ardulink://serial"));
 
@@ -79,46 +76,31 @@ public class SerialLinkFactoryIntegrationTest {
 		port.setValue("anyString");
 		baudrate.setValue(115200);
 	}
-	
+
 	@Test
-	public void cantConnectWithoutPort() {
+	void cantConnectWithoutPort() {
 		LinkManager connectionManager = LinkManager.getInstance();
-		final Configurer configurer = connectionManager
-				.getConfigurer(URIs.newURI("ardulink://serial?baudrate=9600"));
-		
+		Configurer configurer = connectionManager.getConfigurer(URIs.newURI("ardulink://serial?baudrate=9600"));
+
 		ConfigAttribute searchport = configurer.getAttribute("searchport");
 		assertEquals(searchport.getValue(), FALSE);
 
-		@LapsedWith(module = JDK8, value = "Lambda")
-		ThrowingRunnable runnable = new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				configurer.newLink();
-			}
-		};
-		assertThrows(IllegalStateException.class, runnable);
+		assertThrows(IllegalStateException.class, () -> configurer.newLink());
 	}
 
 	@Test
-	public void canConnectWithoutPortButSearchEnabled() {
+	void canConnectWithoutPortButSearchEnabled() {
 		LinkManager connectionManager = LinkManager.getInstance();
-		final Configurer configurer = connectionManager
+		Configurer configurer = connectionManager
 				.getConfigurer(URIs.newURI("ardulink://serial?searchport=true&baudrate=9600&pingprobe=false"));
-		
+
 		ConfigAttribute searchport = configurer.getAttribute("searchport");
 		assertEquals(searchport.getValue(), TRUE);
-		
+
 		// if there aren't devices connected an exception is thrown
 		ConfigAttribute port = configurer.getAttribute("port");
 		if (port.getChoiceValues().length == 0) {
-			@LapsedWith(module = JDK8, value = "Lambda")
-			RuntimeException exception = assertThrows(RuntimeException.class, new ThrowingRunnable() {
-				@Override
-				public void run() throws Throwable {
-					configurer.newLink();
-				}
-			});
-			assertThat(exception.getMessage(), is("no port found"));
+			assertThat(assertThrows(RuntimeException.class, () -> configurer.newLink()).getMessage(), is("no port found"));
 		} else {
 			assertNotNull(configurer.newLink());
 		}

--- a/ardulink-core-util/pom.xml
+++ b/ardulink-core-util/pom.xml
@@ -11,9 +11,14 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-core-util/src/test/java/org/ardulink/util/IteratorsTest.java
+++ b/ardulink-core-util/src/test/java/org/ardulink/util/IteratorsTest.java
@@ -6,18 +6,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.Arrays;
 import java.util.Iterator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class IteratorsTest {
+class IteratorsTest {
 
 	@Test
-	public void getFirst() {
+	void getFirst() {
 		assertThat(Iterators.getFirst(iteratorOf(1)).get(), is(1));
 		assertThat(Iterators.getFirst(iteratorOf(1, 2)).get(), is(1));
 	}
 
 	@Test
-	public void getLast() {
+	void getLast() {
 		assertThat(Iterators.getLast(iteratorOf(1)).get(), is(1));
 		assertThat(Iterators.getLast(iteratorOf(1, 2)).get(), is(2));
 	}

--- a/ardulink-core-util/src/test/java/org/ardulink/util/ListMultiMapTest.java
+++ b/ardulink-core-util/src/test/java/org/ardulink/util/ListMultiMapTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -32,17 +32,17 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class ListMultiMapTest {
+class ListMultiMapTest {
 
 	@Test
-	public void iteratorOnEmpty() {
+	void iteratorOnEmpty() {
 		ListMultiMap<Integer, String> sut = new ListMultiMap<Integer, String>();
 		Iterator<Entry<Integer, String>> iterator = sut.iterator();
 		assertThat(iterator.hasNext(), is(false));
 	}
 
 	@Test
-	public void iteratorOnSingleElement() {
+	void iteratorOnSingleElement() {
 		ListMultiMap<Integer, String> sut = new ListMultiMap<Integer, String>();
 		sut.put(1, "foo");
 		Iterator<Entry<Integer, String>> iterator = sut.iterator();
@@ -54,7 +54,7 @@ public class ListMultiMapTest {
 	}
 
 	@Test
-	public void iteratorOnCollisionElement() {
+	void iteratorOnCollisionElement() {
 		ListMultiMap<Integer, String> sut = new ListMultiMap<Integer, String>();
 		sut.put(1, "foo");
 		sut.put(1, "bar");

--- a/ardulink-core-util/src/test/java/org/ardulink/util/ObjectsTest.java
+++ b/ardulink-core-util/src/test/java/org/ardulink/util/ObjectsTest.java
@@ -3,22 +3,22 @@ package org.ardulink.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ObjectsTest {
+class ObjectsTest {
 
 	@Test
-	public void equalObjectsResultInTrue() {
+	void equalObjectsResultInTrue() {
 		assertThat(Objects.equals("something", "something"), is(true));
 	}
 
 	@Test
-	public void nullAndNullAreEqual() {
+	void nullAndNullAreEqual() {
 		assertThat(Objects.equals(null, null), is(true));
 	}
 
 	@Test
-	public void twoItemsWhereOneOfThemIsNullResultInFalse() {
+	void twoItemsWhereOneOfThemIsNullResultInFalse() {
 		assertThat(Objects.equals("something", null), is(false));
 		assertThat(Objects.equals(null, "something"), is(false));
 	}

--- a/ardulink-core-util/src/test/java/org/ardulink/util/OptionalTest.java
+++ b/ardulink-core-util/src/test/java/org/ardulink/util/OptionalTest.java
@@ -18,16 +18,13 @@ package org.ardulink.util;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
-import static org.ardulink.util.anno.LapsedWith.JDK8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.ardulink.util.anno.LapsedWith;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -37,109 +34,78 @@ import org.junit.function.ThrowingRunnable;
  * [adsense]
  *
  */
-public class OptionalTest {
+class OptionalTest {
 
 	@Test
-	public void optionalFromNullableWithNullValueIsNotPresent() {
+	void optionalFromNullableWithNullValueIsNotPresent() {
 		assertThat(Optional.ofNullable(null).isPresent(), is(FALSE));
 	}
 
 	@Test
-	public void optionalFromNullableWithNonNullValueIsPresent() {
+	void optionalFromNullableWithNonNullValueIsPresent() {
 		assertThat(Optional.ofNullable("foo").isPresent(), is(TRUE));
 	}
 
 	@Test
-	public void getOnNonPresentOptionalThrowsRTE() {
-		@LapsedWith(module = JDK8, value = "Lambda")
-		ThrowingRunnable runnable = new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				Optional.ofNullable(null).get();
-			}
-		};
-		assertThrows(RuntimeException.class, runnable);
+	void getOnNonPresentOptionalThrowsRTE() {
+		assertThrows(RuntimeException.class, () -> Optional.ofNullable(null).get());
 	}
 
 	@Test
-	public void getOnPresentOptionalReturnsObject() {
+	void getOnPresentOptionalReturnsObject() {
 		assertThat(Optional.ofNullable("foo").get(), is("foo"));
 	}
 
 	@Test
-	public void canCreateInstanceWithNonNullValue() {
+	void canCreateInstanceWithNonNullValue() {
 		assertThat(Optional.of("foo").get(), is("foo"));
 	}
 
 	@Test
-	public void callingOfWithNullValueThrowsRTE() {
-		@LapsedWith(module = JDK8, value = "Lambda")
-		ThrowingRunnable runnable = new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				Optional.of(null);
-			}
-		};
-		assertThrows(RuntimeException.class, runnable);
-
+	void callingOfWithNullValueThrowsRTE() {
+		assertThrows(RuntimeException.class, () -> Optional.of(null));
 	}
 
 	@Test
-	public void doesReturnExistingValueIfQueryingAlternative() {
+	void doesReturnExistingValueIfQueryingAlternative() {
 		assertThat(Optional.ofNullable("foo").orElse("bar"), is("foo"));
 	}
 
 	@Test
-	public void doesReturnAlternativeIfQueryingAlternative() {
-		assertThat(Optional.<String> absent().orElse("bar"), is("bar"));
+	void doesReturnAlternativeIfQueryingAlternative() {
+		assertThat(Optional.<String>absent().orElse("bar"), is("bar"));
 	}
 
 	@Test
-	public void getOrThrowThrowsIllegalStateExceptionOnAbsentOptionals() {
-		@LapsedWith(module = JDK8, value = "Lambda")
-		IllegalStateException exception = assertThrows(IllegalStateException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				Optional.<String> absent().getOrThrow("exception text");
-			}
-		});
-		assertThat(exception.getMessage(), is("exception text"));
+	void getOrThrowThrowsIllegalStateExceptionOnAbsentOptionals() {
+		String text = "exception text";
+		assertThat(assertThrows(IllegalStateException.class, () -> Optional.<String>absent().getOrThrow(text))
+				.getMessage(), is(text));
 	}
 
 	@Test
-	public void getOrThrowReturnsValueOnPresentOptionals() {
+	void getOrThrowReturnsValueOnPresentOptionals() {
 		assertThat(Optional.of("foo").getOrThrow("exception text"), is("foo"));
 	}
 
 	@Test
-	public void canThrowIndividualExceptions() {
-		@LapsedWith(module = JDK8, value = "Lambda")
-		RuntimeException exception = assertThrows(RuntimeException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				Optional.<String> absent().getOrThrow(IllegalArgumentException.class,
-						"exception text");
-			}
-		});
-		assertThat(exception.getMessage(), is("exception text"));
+	void canThrowIndividualExceptions() {
+		String text = "exception text";
+		assertThat(
+				assertThrows(RuntimeException.class,
+						() -> Optional.<String>absent().getOrThrow(IllegalArgumentException.class, text)).getMessage(),
+				is(text));
 	}
 
 	@Test
-	public void doesBreakWithNiceMessageIfExceptionClassDoesNotHaveAstringConstructor() {
+	void doesBreakWithNiceMessageIfExceptionClassDoesNotHaveAstringConstructor() {
 		class MyRTEWithoutAstringConstructor extends RuntimeException {
 			private static final long serialVersionUID = 1L;
 		}
-		@LapsedWith(module = JDK8, value = "Lambda")
-		RuntimeException exception = assertThrows(RuntimeException.class, new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				Optional.<String> absent().getOrThrow(
-						MyRTEWithoutAstringConstructor.class,
-						"no matter what typed here");
-			}
-		});
-		assertThat(exception.getMessage(), is(allOf(
-				containsString(MyRTEWithoutAstringConstructor.class.getName()),
+		RuntimeException exception = assertThrows(RuntimeException.class, () -> Optional.<String>absent()
+				.getOrThrow(MyRTEWithoutAstringConstructor.class, "no matter what typed here"));
+		assertThat(exception.getMessage(), is(allOf(containsString(MyRTEWithoutAstringConstructor.class.getName()),
 				containsString("not"), containsString("String constructor"))));
 	}
+
 }

--- a/ardulink-core-util/src/test/java/org/ardulink/util/PrimitivesTest.java
+++ b/ardulink-core-util/src/test/java/org/ardulink/util/PrimitivesTest.java
@@ -22,7 +22,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -32,76 +33,70 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class PrimitivesTest {
+class PrimitivesTest {
 
 	@Test
-	public void canParseIntAsInt() {
-		assertThat(Primitives.parseAs(int.class, "123"),
-				is((Object) Integer.valueOf(123)));
+	void canParseIntAsInt() {
+		assertThat(Primitives.parseAs(int.class, "123"), is((Object) Integer.valueOf(123)));
 	}
 
 	@Test
-	public void canParseIntAsDouble() {
-		assertThat(Primitives.parseAs(double.class, "123"),
-				is((Object) Double.valueOf(123)));
+	void canParseIntAsDouble() {
+		assertThat(Primitives.parseAs(double.class, "123"), is((Object) Double.valueOf(123)));
 	}
 
 	@Test
-	public void canParseDoubleAsDouble() {
-		assertThat(Primitives.parseAs(double.class, "123.456"),
-				is((Object) Double.valueOf(123.456)));
-	}
-
-	@Test(expected = NumberFormatException.class)
-	public void cannotParseDoubleAsInt() {
-		Primitives.parseAs(int.class, "123.456");
+	void canParseDoubleAsDouble() {
+		assertThat(Primitives.parseAs(double.class, "123.456"), is((Object) Double.valueOf(123.456)));
 	}
 
 	@Test
-	public void testForClassName() {
+	void cannotParseDoubleAsInt() {
+		assertThrows(NumberFormatException.class, () -> {
+			Primitives.parseAs(int.class, "123.456");
+		});
+	}
+
+	@Test
+	void testForClassName() {
 		assertThat(Primitives.forClassName("int"), is(Primitives.INT));
 		assertThat(Primitives.forClassName("double"), is(Primitives.DOUBLE));
-		assertThat(Primitives.forClassName(String.class.getName()),
-				is(nullValue()));
+		assertThat(Primitives.forClassName(String.class.getName()), is(nullValue()));
 	}
 
 	@Test
-	public void isWrapperTypeForNonWrapperReturnsFalse() {
+	void isWrapperTypeForNonWrapperReturnsFalse() {
 		assertThat(Primitives.isWrapperType(int.class), is(FALSE));
 	}
 
 	@Test
-	public void isWrapperTypeForWrapperReturnsTrue() {
+	void isWrapperTypeForWrapperReturnsTrue() {
 		assertThat(Primitives.isWrapperType(Integer.class), is(TRUE));
 	}
 
 	@Test
-	public void allPrimitiveTypesContainsInt() {
+	void allPrimitiveTypesContainsInt() {
 		assertThat(Primitives.allPrimitiveTypes().contains(int.class), is(TRUE));
 	}
 
 	@Test
-	public void unwrapOnNonWrapperTypeReturnsArgument() {
-		assertThat(Primitives.unwrap(String.class).getName(),
-				is(String.class.getName()));
+	void unwrapOnNonWrapperTypeReturnsArgument() {
+		assertThat(Primitives.unwrap(String.class).getName(), is(String.class.getName()));
 	}
 
 	@Test
-	public void unwrapOnWrapperTypeReturnsWrappedPrimitive() {
-		assertThat(Primitives.unwrap(Integer.class).getName(),
-				is(int.class.getName()));
+	void unwrapOnWrapperTypeReturnsWrappedPrimitive() {
+		assertThat(Primitives.unwrap(Integer.class).getName(), is(int.class.getName()));
 	}
 
 	@Test
-	public void wrapOnNonPrimitiveTypeReturnsArgument() {
-		assertThat(Primitives.wrap(String.class).getName(),
-				is(String.class.getName()));
+	void wrapOnNonPrimitiveTypeReturnsArgument() {
+		assertThat(Primitives.wrap(String.class).getName(), is(String.class.getName()));
 	}
 
 	@Test
-	public void wrapOnPrimitiveTypeReturnsWrappedType() {
-		assertThat(Primitives.wrap(int.class).getName(),
-				is(Integer.class.getName()));
+	void wrapOnPrimitiveTypeReturnsWrappedType() {
+		assertThat(Primitives.wrap(int.class).getName(), is(Integer.class.getName()));
 	}
 
 }

--- a/ardulink-core-util/src/test/java/org/ardulink/util/SetMultiMapTest.java
+++ b/ardulink-core-util/src/test/java/org/ardulink/util/SetMultiMapTest.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -36,17 +36,17 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class SetMultiMapTest {
+class SetMultiMapTest {
 
 	@Test
-	public void canPut() {
+	void canPut() {
 		SetMultiMap<Integer, String> s = new SetMultiMap<Integer, String>();
 		assertThat(s.put(1, "foo"), is(TRUE));
 		assertThat(s.asMap(), is(buildMap(1, Collections.singleton("foo"))));
 	}
 
 	@Test
-	public void canPutTwice() {
+	void canPutTwice() {
 		SetMultiMap<Integer, String> s = new SetMultiMap<Integer, String>();
 		assertThat(s.put(1, "foo"), is(TRUE));
 		assertThat(s.put(1, "foo"), is(FALSE));
@@ -54,15 +54,15 @@ public class SetMultiMapTest {
 	}
 
 	@Test
-	public void canRemoveExistingValue() {
+	void canRemoveExistingValue() {
 		SetMultiMap<Integer, String> s = new SetMultiMap<Integer, String>();
 		assertThat(s.put(1, "foo"), is(TRUE));
 		assertThat(s.remove(1, "foo"), is(TRUE));
-		assertThat(s.asMap(), is(Collections.<Integer, Set<String>> emptyMap()));
+		assertThat(s.asMap(), is(Collections.<Integer, Set<String>>emptyMap()));
 	}
 
 	@Test
-	public void canHandleRemovesOfNonExistingValues() {
+	void canHandleRemovesOfNonExistingValues() {
 		SetMultiMap<Integer, String> s = new SetMultiMap<Integer, String>();
 		assertThat(s.put(1, "foo"), is(TRUE));
 		assertThat(s.remove(1, "bar"), is(FALSE));
@@ -70,15 +70,14 @@ public class SetMultiMapTest {
 	}
 
 	@Test
-	public void canHandleRemovesOfNonExistingKeys() {
+	void canHandleRemovesOfNonExistingKeys() {
 		SetMultiMap<Integer, String> s = new SetMultiMap<Integer, String>();
 		assertThat(s.put(1, "foo"), is(TRUE));
 		assertThat(s.remove(2, "foo"), is(FALSE));
 		assertThat(s.asMap(), is(buildMap(1, Collections.singleton("foo"))));
 	}
 
-	private static Map<Integer, Set<String>> buildMap(Integer key,
-			Set<String> value) {
+	private static Map<Integer, Set<String>> buildMap(Integer key, Set<String> value) {
 		Map<Integer, Set<String>> m = new HashMap<Integer, Set<String>>();
 		m.put(key, value);
 		return m;

--- a/ardulink-core-util/src/test/java/org/ardulink/util/URIsTest.java
+++ b/ardulink-core-util/src/test/java/org/ardulink/util/URIsTest.java
@@ -6,9 +6,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class URIsTest {
+class URIsTest {
 
 	// TODO if needed make URLBuilder public and convert to top-level-class. If
 	// not needed, remove whole test class including URLBuilder
@@ -24,33 +24,28 @@ public class URIsTest {
 		}
 
 		public URLBuilder param(String name, String value) {
-			this.base.append(URIs.encode(name)).append('=')
-					.append(URIs.encode(value)).append('&');
+			this.base.append(URIs.encode(name)).append('=').append(URIs.encode(value)).append('&');
 			return this;
 		}
 
 		public URI build() {
 			String string = this.base.toString();
-			return URIs.newURI(string.endsWith("&") ? string.substring(0,
-					string.length() - 1) : string);
+			return URIs.newURI(string.endsWith("&") ? string.substring(0, string.length() - 1) : string);
 		}
 
 	}
 
 	@Test
-	public void simpleURI() throws URISyntaxException {
-		URI uri = new URLBuilder("ardulink://serial-jssc")
-				.param("port", "COM3").build();
+	void simpleURI() throws URISyntaxException {
+		URI uri = new URLBuilder("ardulink://serial-jssc").param("port", "COM3").build();
 		assertThat(uri, is(new URI("ardulink://serial-jssc?port=COM3")));
 	}
 
 	@Test
-	public void queryURIWithSpaceChar() throws URISyntaxException {
+	void queryURIWithSpaceChar() throws URISyntaxException {
 		String base = "http://serial-jssc";
-		URI uri = new URLBuilder(base).param("port", "COM3")
-				.param("name with spaces", "value with spaces").build();
-		assertThat(uri, is(new URI(base
-				+ "?port=COM3&name+with+spaces=value+with+spaces")));
+		URI uri = new URLBuilder(base).param("port", "COM3").param("name with spaces", "value with spaces").build();
+		assertThat(uri, is(new URI(base + "?port=COM3&name+with+spaces=value+with+spaces")));
 	}
 
 }

--- a/ardulink-legacy/pom.xml
+++ b/ardulink-legacy/pom.xml
@@ -25,9 +25,14 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/ardulink-mail/pom.xml
+++ b/ardulink-mail/pom.xml
@@ -10,13 +10,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<!-- camel3 depends on Java8 so we so -->
-	<properties>
-		<compilerVersion>1.8</compilerVersion>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -38,9 +31,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -50,7 +48,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.icegreen</groupId>
-			<artifactId>greenmail</artifactId>
+			<artifactId>greenmail-junit5</artifactId>
 			<version>1.6.14</version>
 			<scope>test</scope>
 		</dependency>

--- a/ardulink-mail/src/test/java/org/ardulink/mail/camel/ArdulinkMailOnCamelIntegrationTest.java
+++ b/ardulink-mail/src/test/java/org/ardulink/mail/camel/ArdulinkMailOnCamelIntegrationTest.java
@@ -34,8 +34,8 @@ import static org.ardulink.mail.test.MailSender.mailFrom;
 import static org.ardulink.mail.test.MailSender.send;
 import static org.ardulink.testsupport.mock.TestSupport.getMock;
 import static org.ardulink.util.MapBuilder.newMapBuilder;
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -63,14 +63,14 @@ import org.ardulink.core.Link;
 import org.ardulink.core.convenience.Links;
 import org.ardulink.util.Joiner;
 import org.ardulink.util.Throwables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.icegreen.greenmail.imap.ImapServer;
-import com.icegreen.greenmail.junit.GreenMailRule;
+import com.icegreen.greenmail.junit5.GreenMailExtension;
 import com.icegreen.greenmail.smtp.SmtpServer;
 
 /**
@@ -81,30 +81,28 @@ import com.icegreen.greenmail.smtp.SmtpServer;
  * [adsense]
  *
  */
-public class ArdulinkMailOnCamelIntegrationTest {
+@Timeout(10)
+class ArdulinkMailOnCamelIntegrationTest {
 
 	private static final String mockURI = "ardulink://mock";
 
 	private Link link;
 
-	@Rule
-	public GreenMailRule mailMock = new GreenMailRule(SMTP_IMAP);
+	@RegisterExtension
+	GreenMailExtension mailMock = new GreenMailExtension(SMTP_IMAP);
 
-	@Rule
-	public Timeout timeout = new Timeout(10, SECONDS);
-
-	@Before
-	public void setup() throws URISyntaxException, Exception {
+	@BeforeEach
+	void setup() throws URISyntaxException, Exception {
 		link = Links.getLink(mockURI);
 	}
 
-	@After
-	public void tearDown() throws IOException {
+	@AfterEach
+	void tearDown() throws IOException {
 		link.close();
 	}
 
 	@Test
-	public void readsFromImap_controlsArdulink_sendsResultToEndpoint() throws Exception {
+	void readsFromImap_controlsArdulink_sendsResultToEndpoint() throws Exception {
 		String receiverUser = "receiver";
 		String username = "loginIdReceiver";
 		String password = "secretOfReceiver";
@@ -126,8 +124,8 @@ public class ArdulinkMailOnCamelIntegrationTest {
 
 			Link mockLink = getMock(link);
 			try {
-				verify(mockLink, timeout(5_000)).switchDigitalPin(digitalPin(1), true);
-				verify(mockLink, timeout(5_000)).switchAnalogPin(analogPin(2), 123);
+				verify(mockLink, timeout(SECONDS.toMillis(5))).switchDigitalPin(digitalPin(1), true);
+				verify(mockLink, timeout(SECONDS.toMillis(5))).switchAnalogPin(analogPin(2), 123);
 
 				MockEndpoint mockEndpoint = context.getEndpoint("mock:result", MockEndpoint.class);
 				mockEndpoint.expectedMessageCount(1);
@@ -156,7 +154,7 @@ public class ArdulinkMailOnCamelIntegrationTest {
 	}
 
 	@Test
-	public void writesResultToSender() throws Exception {
+	void writesResultToSender() throws Exception {
 		String receiverUser = "receiver";
 		String username = "loginIdReceiver";
 		String password = "secretOfReceiver";
@@ -191,7 +189,7 @@ public class ArdulinkMailOnCamelIntegrationTest {
 	}
 
 	@Test
-	public void writesResultToSender_ConfiguredViaProperties() throws Exception {
+	void writesResultToSender_ConfiguredViaProperties() throws Exception {
 		String receiver = "receiver@someReceiverDomain.com";
 		String username = "loginIdReceiver";
 		String password = "secretOfReceiver";

--- a/ardulink-mail/src/test/java/org/ardulink/mail/camel/ArdulinkProducerTest.java
+++ b/ardulink-mail/src/test/java/org/ardulink/mail/camel/ArdulinkProducerTest.java
@@ -33,7 +33,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.apache.camel.support.DefaultMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -43,7 +43,7 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class ArdulinkProducerTest {
+class ArdulinkProducerTest {
 
 	private void setup(String validSender, String commandName, List<String> commands) {
 		try {
@@ -82,7 +82,7 @@ public class ArdulinkProducerTest {
 	}
 
 	@Test
-	public void doesNotAcceptMeesagesWithEmptyBody() throws Exception {
+	void doesNotAcceptMeesagesWithEmptyBody() throws Exception {
 		setup("aValidUser", null, emptyList());
 		setFrom("aValidUser");
 
@@ -94,7 +94,7 @@ public class ArdulinkProducerTest {
 	}
 
 	@Test
-	public void doesNotAcceptMessagesWithNullOrEmptyFromAddress() throws Exception {
+	void doesNotAcceptMessagesWithNullOrEmptyFromAddress() throws Exception {
 		setup("anyuser", null, emptyList());
 
 		MockEndpoint mockEndpoint = getMockEndpoint();
@@ -105,7 +105,7 @@ public class ArdulinkProducerTest {
 	}
 
 	@Test
-	public void doesNotAcceptMessagesWhereScenarioNameIsNotKnown() throws Exception {
+	void doesNotAcceptMessagesWhereScenarioNameIsNotKnown() throws Exception {
 		String anyUser = "anyuser";
 		setup(anyUser, null, emptyList());
 
@@ -120,7 +120,7 @@ public class ArdulinkProducerTest {
 	}
 
 	@Test
-	public void doesProcessDigitalPinMessages() throws Exception {
+	void doesProcessDigitalPinMessages() throws Exception {
 		String switchDigital7 = alpProtocolMessage(POWER_PIN_SWITCH).forPin(7).withState(true);
 
 		String anyUser = "anyuser";
@@ -139,7 +139,7 @@ public class ArdulinkProducerTest {
 	}
 
 	@Test
-	public void doesProcessDigitalAndAnalogPinMessages() throws Exception {
+	void doesProcessDigitalAndAnalogPinMessages() throws Exception {
 		String digital7 = alpProtocolMessage(POWER_PIN_SWITCH).forPin(7).withState(true);
 		String analog8 = alpProtocolMessage(POWER_PIN_INTENSITY).forPin(8).withValue(123);
 

--- a/ardulink-mqtt/pom.xml
+++ b/ardulink-mqtt/pom.xml
@@ -9,13 +9,6 @@
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
 
-	<!-- ardulink-camel depends on Java8 so we can use it too -->
-	<properties>
-		<compilerVersion>1.8</compilerVersion>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.ardulink</groupId>
@@ -56,9 +49,14 @@
 			<artifactId>args4j</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/ardulink-mqtt/src/test/java/org/ardulink/mqtt/camel/AggregateThrottleTest.java
+++ b/ardulink-mqtt/src/test/java/org/ardulink/mqtt/camel/AggregateThrottleTest.java
@@ -15,10 +15,10 @@ import org.ardulink.core.Pin;
 import org.ardulink.mqtt.Topics;
 import org.ardulink.mqtt.MqttCamelRouteBuilder;
 import org.ardulink.mqtt.MqttCamelRouteBuilder.CompactStrategy;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
-public class AggregateThrottleTest {
+class AggregateThrottleTest {
 
 	private static final String TOPIC = "foo/bar/topic/";
 
@@ -27,21 +27,19 @@ public class AggregateThrottleTest {
 
 	private CamelContext context;
 
-	@After
-	public void testDown() throws Exception {
+	@AfterEach
+	void testDown() throws Exception {
 		context.stop();
 	}
 
 	@Test
-	public void doesAggregateAnalogsUsingLastAndKeepsDigitals()
-			throws Exception {
+	void doesAggregateAnalogsUsingLastAndKeepsDigitals() throws Exception {
 		context = camelContext(topics(), USE_LATEST);
 		MockEndpoint out = getMockEndpoint();
 
 		out.expectedBodiesReceived(true, false, 12, 1);
-		out.expectedHeaderValuesReceivedInAnyOrder(PUBLISH_HEADER,
-				"foo/bar/topic/D0", "foo/bar/topic/D0", "foo/bar/topic/A1",
-				"foo/bar/topic/A0");
+		out.expectedHeaderValuesReceivedInAnyOrder(PUBLISH_HEADER, "foo/bar/topic/D0", "foo/bar/topic/D0",
+				"foo/bar/topic/A1", "foo/bar/topic/A0");
 
 		simArduinoSends(alpMessage(analogPin(0), 1));
 		simArduinoSends(alpMessage(analogPin(0), 3));
@@ -55,14 +53,12 @@ public class AggregateThrottleTest {
 	}
 
 	@Test
-	public void agregateAnalogsSeparatlyUsingAverageAndKeepsDigitals()
-			throws Exception {
+	void agregateAnalogsSeparatlyUsingAverageAndKeepsDigitals() throws Exception {
 		context = camelContext(topics(), AVERAGE);
 		MockEndpoint out = getMockEndpoint();
 		out.expectedBodiesReceived(true, false, 5, 500);
-		out.expectedHeaderValuesReceivedInAnyOrder(PUBLISH_HEADER,
-				"foo/bar/topic/D0", "foo/bar/topic/D0", "foo/bar/topic/A1",
-				"foo/bar/topic/A0");
+		out.expectedHeaderValuesReceivedInAnyOrder(PUBLISH_HEADER, "foo/bar/topic/D0", "foo/bar/topic/D0",
+				"foo/bar/topic/A1", "foo/bar/topic/A0");
 
 		simArduinoSends(alpMessage(analogPin(0), 1));
 		simArduinoSends(alpMessage(analogPin(0), 3));
@@ -80,8 +76,7 @@ public class AggregateThrottleTest {
 	}
 
 	private String alpMessage(Pin pin, Object value) {
-		return String.format("alp://%sred/%s/%s", pin.is(ANALOG) ? "a" : "d",
-				pin.pinNum(), alpValue(value));
+		return String.format("alp://%sred/%s/%s", pin.is(ANALOG) ? "a" : "d", pin.pinNum(), alpValue(value));
 	}
 
 	private Integer alpValue(Object value) {
@@ -103,8 +98,7 @@ public class AggregateThrottleTest {
 
 	private CamelContext camelContext(Topics topics, CompactStrategy compactStrategy) throws Exception {
 		CamelContext context = new DefaultCamelContext();
-		new MqttCamelRouteBuilder(context, topics).compact(compactStrategy, 1,
-				SECONDS).fromSomethingToMqtt(IN, OUT);
+		new MqttCamelRouteBuilder(context, topics).compact(compactStrategy, 1, SECONDS).fromSomethingToMqtt(IN, OUT);
 		context.start();
 		return context;
 	}

--- a/ardulink-mqtt/src/test/java/org/ardulink/mqtt/camel/MqttMainStandaloneIntegrationTest.java
+++ b/ardulink-mqtt/src/test/java/org/ardulink/mqtt/camel/MqttMainStandaloneIntegrationTest.java
@@ -16,10 +16,8 @@ limitations under the License.
 
 package org.ardulink.mqtt.camel;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.ardulink.util.ServerSockets.freePort;
-import static org.ardulink.util.anno.LapsedWith.JDK8;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.camel.FailedToStartRouteException;
 import org.ardulink.mqtt.CommandLineArguments;
@@ -27,12 +25,9 @@ import org.ardulink.mqtt.MqttBroker;
 import org.ardulink.mqtt.MqttBroker.Builder;
 import org.ardulink.mqtt.MqttMain;
 import org.ardulink.util.Strings;
-import org.ardulink.util.anno.LapsedWith;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -42,7 +37,8 @@ import org.junit.rules.Timeout;
  * [adsense]
  *
  */
-public class MqttMainStandaloneIntegrationTest {
+@Timeout(10)
+class MqttMainStandaloneIntegrationTest {
 
 	private final CommandLineArguments args = args();
 	private String brokerUser;
@@ -97,17 +93,14 @@ public class MqttMainStandaloneIntegrationTest {
 		return !Strings.nullOrEmpty(brokerPassword) && brokerPassword != null;
 	}
 
-	@Rule
-	public Timeout timeout = new Timeout(10, SECONDS);
-
 	@Test
-	public void clientCanConnectToNewlyStartedBroker() throws Exception {
+	void clientCanConnectToNewlyStartedBroker() throws Exception {
 		withBrokerPort(freePort());
 		runMain();
 	}
 
 	@Test
-	public void clientCanConnectUsingCredentialsToNewlyStartedBroker() throws Exception {
+	void clientCanConnectUsingCredentialsToNewlyStartedBroker() throws Exception {
 		String user = "someUser";
 		String password = "someSecret";
 		withBrokerPort(freePort()).withBrokerUser(user).withBrokerPassword(password).withClientUser(user)
@@ -116,20 +109,12 @@ public class MqttMainStandaloneIntegrationTest {
 	}
 
 	@Test
-	public void clientFailsToConnectUsingWrongCredentialsToNewlyStartedBroker() throws Exception {
+	void clientFailsToConnectUsingWrongCredentialsToNewlyStartedBroker() throws Exception {
 		String user = "someUser";
 		withBrokerPort(freePort()).withBrokerUser(user).withBrokerPassword("theBrokersPassword").withClientUser(user)
 				.withClientPassword("notTheBrokersPassword");
 //		exceptions.expectMessage("CONNECTION_REFUSED_BAD_USERNAME_OR_PASSWORD");
-		@LapsedWith(module = JDK8, value = "Lambda")
-		ThrowingRunnable runnable = new ThrowingRunnable() {
-			@Override
-			public void run() throws Throwable {
-				runMain();
-			}
-		};
-		assertThrows(FailedToStartRouteException.class, runnable);
-
+		assertThrows(FailedToStartRouteException.class, () -> runMain());
 	}
 
 	private void runMain() throws Exception {
@@ -149,10 +134,11 @@ public class MqttMainStandaloneIntegrationTest {
 	}
 
 	@Test
-	@Ignore
+	@Disabled
+
 	// test fails with io.netty.handler.codec.DecoderException:
-	// javax.net.ssl.SSLHandshakeException: no cipher suites in common
-	public void clientCanConnectUsingCredentialsToNewlyStartedSslBroker() throws Exception {
+
+	void clientCanConnectUsingCredentialsToNewlyStartedSslBroker() throws Exception {
 		String user = "someUser";
 		String password = "someSecret";
 		withSsl().withBrokerPort(freePort()).withBrokerUser(user).withBrokerPassword(password).withClientUser(user)

--- a/ardulink-networkproxyserver/pom.xml
+++ b/ardulink-networkproxyserver/pom.xml
@@ -30,9 +30,14 @@
 			<artifactId>args4j</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/ardulink-networkproxyserver/src/test/java/org/ardulink/connection/proxy/NetworkProxyServerTest.java
+++ b/ardulink-networkproxyserver/src/test/java/org/ardulink/connection/proxy/NetworkProxyServerTest.java
@@ -2,7 +2,6 @@ package org.ardulink.connection.proxy;
 
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.ardulink.core.Pin.analogPin;
 import static org.ardulink.core.proto.impl.ALProtoBuilder.alpProtocolMessage;
 import static org.ardulink.core.proto.impl.ALProtoBuilder.ALPProtocolKey.POWER_PIN_INTENSITY;
@@ -31,25 +30,21 @@ import org.ardulink.core.proto.impl.ArdulinkProtocol2;
 import org.ardulink.core.proxy.ProxyLinkConfig;
 import org.ardulink.core.proxy.ProxyLinkFactory;
 import org.ardulink.util.anno.LapsedWith;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-public class NetworkProxyServerTest {
+@Timeout(15)
+class NetworkProxyServerTest {
 
-	@Rule
-	public Timeout timeout = new Timeout(15, SECONDS);
-
-	private final StringBuilder proxySideReceived = new StringBuilder(); 
+	private final StringBuilder proxySideReceived = new StringBuilder();
 	private final Connection proxySideConnection = new Connection() {
 
 		@Override
 		public void close() throws IOException {
 			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
@@ -60,36 +55,33 @@ public class NetworkProxyServerTest {
 		@Override
 		public void addListener(Listener listener) {
 			// TODO Auto-generated method stub
-			
 		}
 
 		@Override
 		public void removeListener(Listener listener) {
 			// TODO Auto-generated method stub
-			
 		}
-		
+
 	};
 
 	private ConnectionBasedLink clientSideLink;
 
-	@Before
-	public void setup() throws InterruptedException, UnknownHostException, IOException {
+	@BeforeEach
+	void setup() throws InterruptedException, UnknownHostException, IOException {
 		int freePort = freePort();
 		startServerInBackground(freePort);
 		this.clientSideLink = clientLinkToServer("localhost", freePort);
 	}
 
 	@Test
-	public void proxyServerDoesReceiveMessagesSentByClient() throws Exception {
+	void proxyServerDoesReceiveMessagesSentByClient() throws Exception {
 		int times = 3;
 		for (int i = 0; i < times; i++) {
 			this.clientSideLink.switchAnalogPin(analogPin(1), 2);
 		}
 
-		String message = alpProtocolMessage(POWER_PIN_INTENSITY).forPin(1).withValue(2)
-				+ "\n";
-		assertReceived(message+message+message, times);
+		String message = alpProtocolMessage(POWER_PIN_INTENSITY).forPin(1).withValue(2) + "\n";
+		assertReceived(message + message + message, times);
 	}
 
 	@LapsedWith(value = JDK8, module = "Awaitility")

--- a/ardulink-rest/pom.xml
+++ b/ardulink-rest/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>ardulink-rest</artifactId>
 
@@ -9,13 +7,6 @@
 		<artifactId>parent</artifactId>
 		<version>2.1.2-SNAPSHOT</version>
 	</parent>
-
-	<!-- camel3 depends on Java8 so we so -->
-	<properties>
-		<compilerVersion>1.8</compilerVersion>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
 
 	<dependencies>
 		<dependency>
@@ -64,13 +55,25 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- Mocktio has some weird dependency on junit4 -->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/ardulink-rest/src/test/java/org/ardulink/rest/ArdulinkRestTest.java
+++ b/ardulink-rest/src/test/java/org/ardulink/rest/ArdulinkRestTest.java
@@ -35,8 +35,8 @@ import org.ardulink.core.Link;
 import org.ardulink.core.convenience.Links;
 import org.ardulink.rest.main.CommandLineArguments;
 import org.ardulink.rest.main.RestMain;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -46,15 +46,15 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class ArdulinkRestTest {
+class ArdulinkRestTest {
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		port = freePort();
 	}
 
 	@Test
-	public void canSwitchDigitalPin() throws Exception {
+	void canSwitchDigitalPin() throws Exception {
 		try (Link link = Links.getLink("ardulink://mock")) {
 			Link mock = getMock(link);
 			try (RestMain main = runRestComponent("ardulink://mock")) {
@@ -68,7 +68,7 @@ public class ArdulinkRestTest {
 	}
 
 	@Test
-	public void canSwitchAnalogPin() throws Exception {
+	void canSwitchAnalogPin() throws Exception {
 		try (Link link = Links.getLink("ardulink://mock")) {
 			Link mock = getMock(link);
 			try (RestMain main = runRestComponent("ardulink://mock")) {
@@ -82,7 +82,7 @@ public class ArdulinkRestTest {
 	}
 
 	@Test
-	public void canReadDigitalPin() throws Exception {
+	void canReadDigitalPin() throws Exception {
 		int pin = 5;
 		boolean state = true;
 		try (AbstractListenerLink link = createAbstractListenerLink(digitalPinValueChanged(digitalPin(pin), state));
@@ -92,7 +92,7 @@ public class ArdulinkRestTest {
 	}
 
 	@Test
-	public void canReadAnalogPin() throws Exception {
+	void canReadAnalogPin() throws Exception {
 		int pin = 7;
 		int value = 456;
 		try (AbstractListenerLink link = createAbstractListenerLink(analogPinValueChanged(analogPin(pin), value));
@@ -102,7 +102,7 @@ public class ArdulinkRestTest {
 	}
 
 	@Test
-	public void canEnableAndDisableListeningDigitalPin() throws Exception {
+	void canEnableAndDisableListeningDigitalPin() throws Exception {
 		int pin = 5;
 		try (Link link = Links.getLink("ardulink://mock")) {
 			Link mock = getMock(link);
@@ -117,7 +117,7 @@ public class ArdulinkRestTest {
 	}
 
 	@Test
-	public void canEnableAndDisableListeningAnalogPin() throws Exception {
+	void canEnableAndDisableListeningAnalogPin() throws Exception {
 		int pin = 7;
 		try (Link link = Links.getLink("ardulink://mock")) {
 			Link mock = getMock(link);

--- a/ardulink-rest/src/test/java/org/ardulink/rest/main/ArdulinkRestMainTest.java
+++ b/ardulink-rest/src/test/java/org/ardulink/rest/main/ArdulinkRestMainTest.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 
 import org.ardulink.core.Link;
 import org.ardulink.core.convenience.Links;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.kohsuke.args4j.CmdLineException;
 
 /**
@@ -41,15 +41,15 @@ import org.kohsuke.args4j.CmdLineException;
  * [adsense]
  *
  */
-public class ArdulinkRestMainTest {
+class ArdulinkRestMainTest {
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		port = freePort();
 	}
 
 	@Test
-	public void canParseArgs() throws IOException, CmdLineException {
+	void canParseArgs() throws IOException, CmdLineException {
 		CommandLineArguments args = RestMain
 				.tryParse("-connection", "ardulink://abc", "-bind", "someHost", "-port", "123").get();
 		assertThat(args.connection, is("ardulink://abc"));
@@ -58,7 +58,7 @@ public class ArdulinkRestMainTest {
 	}
 
 	@Test
-	public void canStartMainWithArgs() throws IOException, CmdLineException {
+	void canStartMainWithArgs() throws IOException, CmdLineException {
 		CommandLineArguments args = args();
 		try (RestMain restMain = new RestMain(args); Link mock = getMock(Links.getLink(args.connection))) {
 			int pin = 5;

--- a/ardulink-rest/src/test/java/org/ardulink/rest/swagger/ArdulinkRestSwaggerTest.java
+++ b/ardulink-rest/src/test/java/org/ardulink/rest/swagger/ArdulinkRestSwaggerTest.java
@@ -36,8 +36,8 @@ import org.ardulink.core.Link;
 import org.ardulink.core.convenience.Links;
 import org.ardulink.rest.main.CommandLineArguments;
 import org.ardulink.rest.main.RestMain;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.BrowserContext;
@@ -54,19 +54,19 @@ import com.microsoft.playwright.options.AriaRole;
  * [adsense]
  *
  */
-public class ArdulinkRestSwaggerTest {
+class ArdulinkRestSwaggerTest {
 
 	private static final long TIMEOUT = SECONDS.toMillis(5);
 	private static final String SYS_PROP_PREFIX = "ardulink.test.";
 	private static final String MOCK_URI = "ardulink://mock";
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		port = freePort();
 	}
 
 	@Test
-	public void canAccesApiDoc() throws Exception {
+	void canAccesApiDoc() throws Exception {
 		try (RestMain main = runRestComponent()) {
 			given().port(port).get("/api-docs").then().assertThat().statusCode(200).contentType(JSON) //
 					.body("info.title", equalTo("User API")) //
@@ -77,7 +77,7 @@ public class ArdulinkRestSwaggerTest {
 	}
 
 	@Test
-	public void canAccesApiUi_GotoApiDocs() throws Exception {
+	void canAccesApiUi_GotoApiDocs() throws Exception {
 		try (RestMain main = runRestComponent()) {
 			try (Playwright playwright = Playwright.create()) {
 				Browser browser = browser(playwright.chromium());
@@ -95,7 +95,7 @@ public class ArdulinkRestSwaggerTest {
 	}
 
 	@Test
-	public void canAccesApiUi_ExecPutRequestViaApiBrowser() throws Exception {
+	void canAccesApiUi_ExecPutRequestViaApiBrowser() throws Exception {
 		int pin = 13;
 		int value = 42;
 		try (RestMain main = runRestComponent()) {

--- a/ardulink-swing/pom.xml
+++ b/ardulink-swing/pom.xml
@@ -21,9 +21,14 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+		    <groupId>org.hamcrest</groupId>
+		    <artifactId>hamcrest-library</artifactId>
+		    <scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/ardulink-swing/src/test/java/org/ardulink/gui/connectionpanel/GenericConnectionPanelTest.java
+++ b/ardulink-swing/src/test/java/org/ardulink/gui/connectionpanel/GenericConnectionPanelTest.java
@@ -34,7 +34,7 @@ import org.ardulink.gui.DummyLinkConfig;
 import org.ardulink.util.Optional;
 import org.ardulink.util.URIs;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * [ardulinktitle] [ardulinkversion]
@@ -44,56 +44,45 @@ import org.junit.Test;
  * [adsense]
  *
  */
-public class GenericConnectionPanelTest {
+class GenericConnectionPanelTest {
 
 	private final URI uri = URIs.newURI("ardulink://dummy");
 	private final GenericPanelBuilder sut = new GenericPanelBuilder();
 
 	@Test
-	public void canHandle() {
+	void canHandle() {
 		assertThat(sut.canHandle(uri), is(true));
 	}
 
 	@Test
-	public void hasSubPanelWithConnectionIndividualComponents() {
+	void hasSubPanelWithConnectionIndividualComponents() {
 
 		DummyLinkConfig dlc = new DummyLinkConfig();
 
-		JPanel panel = sut.createPanel(LinkManager.getInstance().getConfigurer(
-				uri));
-		JComboBox comboBox = findFirst(JComboBox.class, componentsOf(panel))
-				.getOrThrow("No %s found on panel %s",
-						JComboBox.class.getName(), panel);
+		JPanel panel = sut.createPanel(LinkManager.getInstance().getConfigurer(uri));
+		JComboBox comboBox = findFirst(JComboBox.class, componentsOf(panel)).getOrThrow("No %s found on panel %s",
+				JComboBox.class.getName(), panel);
 		comboBox.setSelectedItem("ardulink://dummy");
-		assertThat(panel,
-				has(row(0).withLabel("1_aIntValue")
-						.withValue(dlc.getIntValue())));
-		assertThat(panel, has(row(1).withLabel("2_aBooleanValue").withYesNo()
-				.withValue(dlc.getBooleanValue())));
+		assertThat(panel, has(row(0).withLabel("1_aIntValue").withValue(dlc.getIntValue())));
+		assertThat(panel, has(row(1).withLabel("2_aBooleanValue").withYesNo().withValue(dlc.getBooleanValue())));
 		assertThat(panel, has(row(2).withLabel("3_aStringValue").withValue("")));
-		Object[] choices1 = dlc.someValuesForChoiceWithoutNull().toArray(
-				new String[0]);
-		assertThat(panel, has(row(3).withLabel("4_aStringValueWithChoices")
-				.withChoice(choices1).withValue(choices1[0])));
-		Object[] choices2 = dlc.someValuesForChoiceWithNull().toArray(
-				new String[0]);
+		Object[] choices1 = dlc.someValuesForChoiceWithoutNull().toArray(new String[0]);
 		assertThat(panel,
-				has(row(4).withLabel("5_aStringValueWithChoicesIncludingNull")
-						.withChoice(choices2).withValue(null)));
+				has(row(3).withLabel("4_aStringValueWithChoices").withChoice(choices1).withValue(choices1[0])));
+		Object[] choices2 = dlc.someValuesForChoiceWithNull().toArray(new String[0]);
+		assertThat(panel,
+				has(row(4).withLabel("5_aStringValueWithChoicesIncludingNull").withChoice(choices2).withValue(null)));
 		Object[] timeUnits = TimeUnit.values();
-		assertThat(panel,
-				has(row(5).withLabel("6_aEnumValue").withChoice(timeUnits)
-						.withValue(dlc.getEnumValue())));
+		assertThat(panel, has(row(5).withLabel("6_aEnumValue").withChoice(timeUnits).withValue(dlc.getEnumValue())));
 	}
 
-	private <T> Optional<T> findFirst(Class<T> clazz,
-			List<? extends Component> components) {
+	private <T> Optional<T> findFirst(Class<T> clazz, List<? extends Component> components) {
 		for (Component component : components) {
 			if (clazz.isInstance(component)) {
 				return Optional.of(clazz.cast(component));
 			}
 		}
-		return Optional.<T> absent();
+		return Optional.<T>absent();
 	}
 
 	private <T> Matcher<T> has(Matcher<T> matcher) {

--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,13 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<compilerVersion>1.6</compilerVersion>
+		<compilerVersion>1.8</compilerVersion>
 		<maven.compiler.source>${compilerVersion}</maven.compiler.source>
 		<maven.compiler.target>${compilerVersion}</maven.compiler.target>
 		<args4j.version>2.33</args4j.version>
 		<slf4j.version>2.0.6</slf4j.version>
-		<junit.version>4.13.2</junit.version>
+		<junit.version>5.9.2</junit.version>
+		<hamcrest.version>2.2</hamcrest.version>
 		<mockito.version>1.10.19</mockito.version>
 		<!-- The next LTS release Camel 3.14, scheduled for December 2021, will be the last release to support Java 8 -->
 		<!-- https://camel.apache.org/blog/2021/09/eol-java8/ -->
@@ -102,6 +103,14 @@
 	<build>
 		<pluginManagement>
 			<plugins>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.1</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0-M6</version>
+				</plugin>
 				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>3.5.0</version>
@@ -170,7 +179,7 @@
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
-        		<version>3.3.1</version>
+				<version>3.3.1</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -261,9 +270,16 @@
 				<version>${slf4j.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
 				<version>${junit.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.hamcrest</groupId>
+				<artifactId>hamcrest-library</artifactId>
+				<version>${hamcrest.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
minimal Java version now is Java 8 (as it's prerequisite for JUnit Jupiter) 
But code has not been converted to Java8 so #94 stays open

Fixes #95 (at least without migration to assertJ)
