### PR TITLE
Fix cross-request state leakage in REST pin reads

### DIFF
--- a/ardulink-rest/src/main/java/org/ardulink/rest/RestRouteBuilder.java
+++ b/ardulink-rest/src/main/java/org/ardulink/rest/RestRouteBuilder.java
@@ -48,8 +48,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -99,8 +98,7 @@ public class RestRouteBuilder extends RouteBuilder {
 
 	@Override
 	public void configure() throws Exception {
-		AtomicReference<FromDeviceMessagePinStateChanged> messageRef = new AtomicReference<>();
-		CountDownLatch latch = new CountDownLatch(1);
+		ConcurrentHashMap<Pin, FromDeviceMessagePinStateChanged> messages = new ConcurrentHashMap<>();
 
 		String patchAnalog = "direct:patchAnalog-" + identityHashCode(this);
 		String patchDigital = "direct:patchDigital-" + identityHashCode(this);
@@ -132,13 +130,11 @@ public class RestRouteBuilder extends RouteBuilder {
 		;
 		from(patchAnalog).process(exchange -> patchAnalog(exchange)).to(target);
 		from(patchDigital).process(exchange -> patchDigital(exchange)).to(target);
-		from(readAnalog).process(exchange -> readAnalog(exchange))
-				.process(exchange -> readQueue(exchange, messageRef, latch));
-		from(readDigital).process(exchange -> readDigital(exchange))
-				.process(exchange -> readQueue(exchange, messageRef, latch));
+		from(readAnalog).process(exchange -> readAnalog(exchange)).process(exchange -> readQueue(exchange, messages));
+		from(readDigital).process(exchange -> readDigital(exchange)).process(exchange -> readQueue(exchange, messages));
 		from(switchAnalog).process(exchange -> switchAnalog(exchange)).to(target);
 		from(switchDigital).process(exchange -> switchDigital(exchange)).to(target);
-		writeArduinoMessagesTo(target, messageRef, latch);
+		writeArduinoMessagesTo(target, messages);
 	}
 
 	private void swagger(String apidocs) {
@@ -209,19 +205,18 @@ public class RestRouteBuilder extends RouteBuilder {
 		message.setHeader("location", location);
 	}
 
-	private static void readQueue(Exchange exchange, AtomicReference<FromDeviceMessagePinStateChanged> messageRef,
-			CountDownLatch latch) throws InterruptedException {
+	private static void readQueue(Exchange exchange, Map<Pin, FromDeviceMessagePinStateChanged> messages)
+			throws InterruptedException {
 		Message message = exchange.getMessage();
 		Pin pinOfMessage = extractPin(message);
 
 		for (Countdown countdown = createStarted(1, SECONDS); !countdown.finished();) {
-			if (latch.await(countdown.remaining(MILLISECONDS), MILLISECONDS)) {
-				FromDeviceMessagePinStateChanged polled = messageRef.get();
-				if (pinOfMessage.equals(polled.getPin())) {
-					message.setBody(polled.getValue(), String.class);
-					return;
-				}
+			FromDeviceMessagePinStateChanged polled = messages.get(pinOfMessage);
+			if (polled != null) {
+				message.setBody(polled.getValue(), String.class);
+				return;
 			}
+			MILLISECONDS.sleep(Math.min(10, countdown.remaining(MILLISECONDS)));
 		}
 		throw new IllegalStateException("Timeout retrieving message from arduino");
 	}
@@ -289,16 +284,15 @@ public class RestRouteBuilder extends RouteBuilder {
 		return message;
 	}
 
-	private void writeArduinoMessagesTo(String arduino, AtomicReference<FromDeviceMessagePinStateChanged> messageRef,
-			CountDownLatch latch) {
+	private void writeArduinoMessagesTo(String arduino, Map<Pin, FromDeviceMessagePinStateChanged> messages) {
 		ALPByteStreamProcessor byteStreamProcessor = new ALPByteStreamProcessor();
 		from(arduino).process(exchange -> {
 			String body = exchange.getMessage().getBody(String.class);
 			FromDeviceMessage fromDevice = getFirst(parse(byteStreamProcessor, byteStreamProcessor.toBytes(body)))
 					.orElseThrow(() -> new IllegalStateException("Cannot handle " + body));
 			if (fromDevice instanceof FromDeviceMessagePinStateChanged) {
-				messageRef.set((FromDeviceMessagePinStateChanged) fromDevice);
-				latch.countDown();
+				FromDeviceMessagePinStateChanged message = (FromDeviceMessagePinStateChanged) fromDevice;
+				messages.put(message.getPin(), message);
 			}
 		});
 	}

--- a/ardulink-rest/src/test/java/org/ardulink/rest/ArdulinkRestTest.java
+++ b/ardulink-rest/src/test/java/org/ardulink/rest/ArdulinkRestTest.java
@@ -17,6 +17,7 @@ limitations under the License.
 package org.ardulink.rest;
 
 import static io.restassured.RestAssured.given;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.IntStream.range;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.ardulink.core.Pin.analogPin;
@@ -38,6 +39,9 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.verify;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 
@@ -151,6 +155,40 @@ class ArdulinkRestTest {
 				fireEvent(link, analogPinValueChanged(pin, v));
 			}));
 			given().get("/pin/analog/{pin}", pin.pinNum()).then().statusCode(200).body(is(String.valueOf(lastValue)));
+		}
+	}
+
+	@Test
+	void concurrentReadsDoNotSeeEachOthersValues() throws Exception {
+		AnalogPin analogPin = analogPin(7);
+		DigitalPin digitalPin = digitalPin(5);
+		int analogValue = 456;
+		boolean digitalValue = true;
+		try (Link link = Links.getLink(mockUri); RestMain main = runRestComponent(mockUri)) {
+			fireEvent(link, digitalPinValueChanged(digitalPin, digitalValue));
+			fireEvent(link, analogPinValueChanged(analogPin, analogValue));
+			ExecutorService executor = Executors.newFixedThreadPool(2);
+			try {
+				Future<?> analogReader = executor
+						.submit(() -> given().get("/pin/analog/" + analogPin.pinNum()).then().statusCode(200)
+								.body(is(String.valueOf(analogValue))));
+				Future<?> digitalReader = executor
+						.submit(() -> given().get("/pin/digital/" + digitalPin.pinNum()).then().statusCode(200)
+								.body(is(String.valueOf(digitalValue))));
+				analogReader.get(30, SECONDS);
+				digitalReader.get(30, SECONDS);
+			} finally {
+				executor.shutdownNow();
+			}
+		}
+	}
+
+	@Test
+	void readDoesNotReturnValueOfAnotherPin() throws Exception {
+		DigitalPin pin = digitalPin(7);
+		try (Link link = Links.getLink(mockUri); RestMain main = runRestComponent(mockUri)) {
+			fireEvent(link, analogPinValueChanged(analogPin(7), 456));
+			given().get("/pin/digital/{pin}", pin.pinNum()).then().statusCode(500).and().body(containsString("Timeout"));
 		}
 	}
 


### PR DESCRIPTION
A single shared AtomicReference plus a one-shot CountDownLatch meant a message for one pin could overwrite the value another request was waiting for, so concurrent reads of different pins raced and one could time out or return another pin's value. Track the latest value per Pin in a ConcurrentHashMap instead, and poll only the requested pin within the existing one-second timeout.