### PR TITLE
Add opt-in OWASP dependency-check to the build

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,51 @@
+name: OWASP Dependency-Check
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - "**/pom.xml"
+      - "dependency-check/**"
+      - ".github/workflows/dependency-check.yml"
+  pull_request:
+    branches: ["master"]
+    paths:
+      - "**/pom.xml"
+      - "dependency-check/**"
+      - ".github/workflows/dependency-check.yml"
+  schedule:
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up JDK
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          java-version: 17
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run OWASP Dependency-Check
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: mvn -B -Powasp -DskipTests -Dmodernizer.skip verify
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dependency-check-report
+          path: "*/target/dependency-check-report.html"

--- a/dependency-check/suppressions.xml
+++ b/dependency-check/suppressions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+	<!-- Suppress findings that are known false positives or not applicable.
+	     Suppress only what you have reviewed and can justify; re-check each
+	     suppression on a regular basis. -->
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
 		<equalsverifier.version>3.19.4</equalsverifier.version>
 		<!-- camel3 is the last version that supports java 11, camel4 needs java 17 -->
 		<camel.version>3.22.4</camel.version>
+		<owasp.dependency.check.version>12.1.3</owasp.dependency.check.version>
 
 		<!-- default image name for JIB -->
 		<image>docker.io/ardulink/${project.artifactId}:${project.version}</image>
@@ -243,6 +244,35 @@
 			<properties>
 				<argLine>-Dardulink.test.playwright.video.path=target/videos</argLine>
 			</properties>
+		</profile>
+		<profile>
+			<id>owasp</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.owasp</groupId>
+						<artifactId>dependency-check-maven</artifactId>
+						<version>${owasp.dependency.check.version}</version>
+						<configuration>
+							<failBuildOnCVSS>7</failBuildOnCVSS>
+							<formats>
+								<format>HTML</format>
+								<format>JSON</format>
+							</formats>
+							<suppressionFiles>
+								<suppressionFile>${maven.multiModuleProjectDirectory}/dependency-check/suppressions.xml</suppressionFile>
+							</suppressionFiles>
+						</configuration>
+						<executions>
+							<execution>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>makerelease</id>


### PR DESCRIPTION
New 'owasp' Maven profile runs dependency-check:check (bound to verify) with a CVSS >= 7 failure threshold, HTML and JSON reports, and a shared suppression file. A weekly GitHub Actions workflow triggers it (and on pom changes) with the NVD API key from secrets; the report is uploaded as an artifact. The profile is opt-in and does not affect the regular build.